### PR TITLE
[TON-852] Add EKS Agent installation documentation

### DIFF
--- a/hugo/content/en/getting_started/integrations/aws.md
+++ b/hugo/content/en/getting_started/integrations/aws.md
@@ -36,7 +36,7 @@ further_reading:
 
 ## Overview
 
-This guide walks you through integrating an Amazon Web Services (AWS) account with Datadog using Datadog's CloudFormation template. After completing setup, you can enable individual AWS service integrations, install the Datadog Agent on EC2 instances for deeper visibility, and configure log forwarding.
+This guide walks you through integrating an Amazon Web Services (AWS) account with Datadog using Datadog's CloudFormation template. After completing setup, you can enable individual AWS service integrations, install the Datadog Agent on EC2 instances and EKS clusters for deeper visibility, and configure log forwarding.
 
 ## Prerequisites
 
@@ -179,7 +179,11 @@ Once you have enabled logs, find them in the [Log Explorer][15] using either the
 
 ## Get more from the Datadog platform
 
-### Deeper visibility with the Datadog Agent on EC2
+### Deeper visibility with the Datadog Agent
+
+You can install and manage the Agent on eligible Amazon EC2 instances and Amazon EKS clusters directly through the AWS integration. See [Install the Datadog Agent through the AWS Integration][62].
+
+#### EC2
 
 By default the Datadog AWS integration crawls the CloudWatch API for AWS-provided metrics, but you can gain even deeper visibility into your EC2 instances with the [Datadog Agent][16]. The Agent is a lightweight daemon that reports metrics and events, and can also be configured for logs and traces. The [Agent Installation][17] section of the Datadog application provides instructions for installing the Agent on a wide variety of operating systems. Many operating systems (for example, Amazon Linux) have one-step installation commands that you can run from the instance terminal to install the Agent:
 {{< img src="getting_started/integrations/integrations-agent-installation.png" alt="The 'Agent' section of the 'Integrations' tab in Datadog. Along the left are displayed a list of supported operating systems for the Datadog Agent. 'Amazon Linux' is highlighted from this list. On the right is displayed 'Use our easy one-step install'. The command for installing the Agent is displayed below this, with the DD_API_KEY section obfuscated.">}}
@@ -209,7 +213,7 @@ Use the [Amazon ECS on AWS Fargate for AWS Batch documentation][58] to run the A
 
 #### EKS
 
-You don't need any specific configuration for Amazon Elastic Kubernetes Service (EKS), as mentioned in the [Kubernetes Distributions documentation][29]. Use the [dedicated Kubernetes documentation][30] to deploy the Agent in your EKS cluster.
+For eligible EKS clusters, you can install and manage the Agent automatically through the [AWS integration][62]. To install the Agent manually, see the [EKS guidance in Kubernetes Distributions][29] and the [Kubernetes installation documentation][30].
 
 #### EKS with Fargate
 
@@ -315,3 +319,4 @@ If you encounter the error `Datadog is not authorized to perform sts:AssumeRole`
 [59]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-get-template.html
 [60]: /integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/
 [61]: /integrations/guide/aws-metric-name-filters/
+[62]: /integrations/guide/aws-agent-installation/

--- a/hugo/content/en/integrations/guide/_index.md
+++ b/hugo/content/en/integrations/guide/_index.md
@@ -38,6 +38,7 @@ cascade:
 
 {{< header-list header="AWS guides" >}}
     {{< nextlink href="getting_started/integrations/aws/" tag=" AWS" >}}AWS integration automatic setup with CloudFormation{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/aws-agent-installation" tag=" AWS" >}}Install the Datadog Agent through the AWS Integration{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-terraform-setup" tag=" AWS" >}}AWS integration automatic setup with Terraform{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-organizations-setup" tag=" AWS" >}}AWS integration multi-account setup for Organizations{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-manual-setup" tag=" AWS" >}}AWS integration manual setup{{< /nextlink >}}

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -107,6 +107,8 @@ Datadog automatically excludes:
 - ECS container instances
 - Instances that already have a non-Datadog-installed Agent
 
+[2]: https://docs.datadoghq.com/integrations/guide/aws-agent-installation/#prerequisites
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -125,6 +127,8 @@ Datadog does not call the Kubernetes API or require Kubernetes credentials. All 
 This installation method supports `ACTIVE` clusters where all workloads run on EC2-backed nodes and at least one node runs Linux. EKS Fargate workloads are not covered.
 
 Datadog does not replace or adopt an existing `datadog_operator` add-on.
+
+[2]: https://docs.datadoghq.com/integrations/guide/aws-agent-installation/#prerequisites
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -278,4 +282,3 @@ To uninstall, remove clusters from a rule, edit the rule's query, or delete the 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/integrations/guide/aws-agent-installation/
-[2]: https://docs.datadoghq.com/integrations/guide/aws-agent-installation/#prerequisites

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -1,7 +1,7 @@
 ---
 title: How Agent Installation through the AWS Integration Works
-description: "Understand how Datadog installs and maintains the Datadog Agent on Amazon EC2 through the AWS integration: the AWS resources created, the installation mechanism, the security model, and the Agent lifecycle."
-private: true # TODO(DOCS-14545): remove at v1 rollout to publish, at the same time as the setup guide this page links to; also add the nextlink entry under "AWS guides" in hugo/content/en/integrations/guide/_index.md at that time
+description: "Understand how Datadog installs and maintains the Datadog Agent on Amazon EC2 and Amazon EKS through the AWS integration: the AWS resources created, the installation mechanism, the security model, and the Agent lifecycle."
+private: true # TODO(DOCS-14545): remove at v1 rollout to publish, at the same time as the setup guide this page links to
 further_reading:
 - link: "https://docs.datadoghq.com/integrations/guide/aws-agent-installation/"
   tag: "Documentation"
@@ -14,11 +14,12 @@ further_reading:
   text: "Fleet Automation"
 ---
 
-This page explains how Datadog installs and maintains the Agent on Amazon EC2 through the AWS integration. For setup instructions and the permissions Datadog requires, see [Install the Datadog Agent through the AWS Integration][1].
+This page explains how Datadog installs and maintains the Agent on Amazon EC2 instances and Amazon EKS clusters through the AWS integration. For setup instructions and the permissions Datadog requires, see [Install the Datadog Agent through the AWS Integration][1].
 
-<div class="alert alert-info">This page covers the Amazon EC2 experience only.</div>
+## Resources that Datadog creates
 
-## AWS resources that Datadog creates
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 The CloudFormation template you launch creates the following resources one time, in a single stack:
 
@@ -42,7 +43,43 @@ Datadog creates the following resources as needed, at install time:
 
 Datadog does not create S3 buckets, event buses, log groups, or SSM parameters, and does not tag your instances.
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+The CloudFormation template you launch creates the following resources one time, in a single stack:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| EventBridge connection | `datadog-agent-resource-update-intake-connection` | Holds your Datadog API and application keys so events can be sent to Datadog |
+| EventBridge API destination | `datadog-agent-resource-update-intake-destination` | Sends events to `https://api.<YOUR_DD_SITE>/api/unstable/instrumenter/events` (capped at 10 events per second) |
+| EventBridge rule | `datadog-agent-resource-update-rule-eks` | Notifies Datadog when a covered cluster changes |
+| IAM role | auto-named | Lets EventBridge send events to the `datadog-agent-resource-update-intake-destination` API destination |
+| IAM role | `datadog-eventbridge-cross-region-role` | Lets other regions forward events to your primary region |
+| AWS Marketplace subscription function and IAM role | auto-named | Accepts the one-time, account-level agreement for the Datadog Operator EKS add-on |
+| IAM permissions boundary | `datadog-instrumenter-eks-ascp-boundary` under `/datadog/instrumenter-boundaries/` | Limits the permissions available to the per-cluster credential synchronization role |
+
+Datadog creates the following resources as needed, at install time:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| EKS add-on | `datadog_operator` | Runs the Datadog Operator, which creates and maintains the Agent resources inside the cluster |
+| EKS add-ons | `aws-secrets-store-csi-driver-provider` and `eks-pod-identity-agent` | Synchronize the Datadog credentials from AWS Secrets Manager into the cluster. Datadog creates these add-ons only when they are absent. |
+| Secrets Manager secret | `/datadog/eks-instrumenter/<ACCOUNT_ID>/<CLUSTER_NAME>` | Holds the Datadog API key for the cluster |
+| Secrets Manager secret | `/datadog/eks-instrumenter/<ACCOUNT_ID>/<CLUSTER_NAME>/application-key` | Holds the cluster-specific Datadog application key |
+| IAM role and inline policy | `dd-eks-ascp-sync-<CLUSTER_NAME>-<HASH>` and `dd-eks-instrumenter-ascp-sync-policy` | Let the credential synchronization service account read only the two cluster-specific secrets |
+| EKS Pod Identity association | `datadog-agent/datadog-ascp-sync` | Associates the credential synchronization service account with its scoped IAM role |
+| Kubernetes Secret | `datadog-agent/datadog-managed-secret` | Makes the API and application keys available to the managed Agent resources |
+| `DatadogAgent` custom resource | `datadog-agent/datadog-agent` | Defines the Agent configuration that the Datadog Operator maintains |
+
+Datadog also creates one application key per cluster with only the **Remote Configuration Read** permission. Datadog does not call the Kubernetes API during installation; the Datadog Operator creates and removes the managed resources inside the cluster.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## How Agent installation works
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 After you save an installation rule, Datadog resolves the query you defined into a fixed list of covered instances. Datadog then runs the following sequence against each one. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
 
@@ -63,7 +100,32 @@ Datadog automatically excludes:
 - ECS container instances
 - Instances that already have a non-Datadog-installed Agent
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+After you save an installation rule, Datadog resolves the query you defined into a fixed list of covered clusters. Datadog then runs the following sequence against each one. For eligibility requirements, see [Prerequisites][2] in the setup guide.
+
+1. Datadog confirms that the cluster is eligible and that the AWS integration role has the required permissions.
+2. Datadog installs or reuses the AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons, then creates the cluster-specific secrets, IAM role, and Pod Identity association used for credential synchronization.
+3. Datadog creates the Datadog Operator EKS add-on in the `datadog-agent` namespace. The add-on synchronizes the API and application keys into the `datadog-managed-secret` Kubernetes Secret.
+4. Datadog updates the add-on configuration to request Agent installation. The Operator creates the `DatadogAgent` resource and its dependent resources inside the cluster.
+5. The Operator reports the result of the requested lifecycle operation to Datadog. Datadog acknowledges that result in the add-on configuration before marking the installation active.
+
+Datadog does not call the Kubernetes API or require Kubernetes credentials. All control-plane operations from Datadog use AWS APIs; the Operator handles the in-cluster resources.
+
+### Supported clusters
+
+This installation method supports `ACTIVE` clusters where all workloads run on EC2-backed nodes and at least one node runs Linux. EKS Fargate workloads are not covered.
+
+Datadog does not replace or adopt an existing `datadog_operator` add-on.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Security, auditing, and change control
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 ### How Datadog gets access
 
@@ -88,7 +150,42 @@ The API key is stored in your own Secrets Manager, encrypted at rest. Only the s
 - Datadog tracks which instances it installed an Agent on, so it cleans up only its own work.
 - When some regions cannot be listed, Datadog skips cleanup for that pass rather than risk uninstalling in bulk.
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+### How Datadog gets access
+
+Datadog uses the same cross-account IAM role as the AWS integration and receives short-lived, temporary credentials. The additional permissions for this installation method let Datadog inspect clusters and manage the EKS add-ons, secrets, IAM role, and Pod Identity association used by the installation. Datadog does not store long-lived AWS credentials or Kubernetes credentials.
+
+### Auditing Datadog's actions
+
+Every AWS action Datadog takes appears in AWS CloudTrail. Resources created for an installation are identifiable by their names and tags: secrets use the `/datadog/eks-instrumenter/` prefix, the credential synchronization role uses the `dd-eks-ascp-sync-` prefix, and the Datadog Operator add-on includes tags that identify the installation and cluster.
+
+### How the API and application keys are handled
+
+The API key and cluster-specific application key are stored in separate AWS Secrets Manager secrets encrypted at rest. The application key has only the **Remote Configuration Read** permission. Only the secret identifiers—not the key values—appear in the EKS add-on configuration.
+
+The credential synchronization service account assumes a dedicated IAM role through EKS Pod Identity. Its inline policy can read only the two secrets for that cluster. The AWS Secrets Store CSI Driver Provider synchronizes their values into `datadog-agent/datadog-managed-secret` for the Operator-managed Agent resources.
+
+### Who can change installations
+
+- **In AWS**: Access is governed by your own IAM policies. Removing the cross-account permissions stops Datadog immediately.
+- **In Datadog**: Viewing installation rules requires the **Hosts Read** permission. Creating, editing, or deleting rules requires the **Agent Install** permission. Rule changes are rate-limited.
+
+### Guardrails
+
+- Datadog does not replace or adopt an existing Datadog Operator add-on.
+- Datadog reuses compatible AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons without modifying them, and leaves them installed during uninstall.
+- Datadog does not replace an existing Pod Identity association for the `datadog-ascp-sync` service account. It reuses one only when it matches the association Datadog previously created.
+- Datadog removes only the Datadog Operator add-on, IAM role, and Pod Identity association that match the recorded installation.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Agent lifecycle and reconciliation
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 ### Rule coverage is fixed at save time
 
@@ -118,9 +215,56 @@ Datadog retries with an increasing delay (1 hour, then 2 hours, up to once per d
 When someone manually removes the Agent from a covered instance, the next reconciliation reinstalls it. The rule is the source of truth. To stop coverage, change the rule.
 </div>
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+### Rule coverage is fixed at save time
+
+A rule covers the list of clusters it resolved to when you saved it, and Datadog does not instrument anything outside that list. Clusters created later are not picked up automatically. To cover them, update the rule, which re-resolves your query against your current clusters.
+
+### How Datadog keeps covered clusters in sync
+
+Datadog continuously maintains the state you define for the covered clusters:
+
+- A full reconciliation runs hourly per AWS account. Reconciliation retries incomplete installations and uninstalls clusters that are no longer covered.
+- Change events from the CloudFormation stack let Datadog react to cluster creation, configuration, version, and tag changes within minutes instead of waiting for the hourly pass.
+- The Datadog Operator continuously reconciles the Agent resources inside each covered cluster.
+
+### What happens when you edit a rule
+
+Datadog re-resolves your query and compares it against the previous list. Clusters no longer covered have the Agent uninstalled. Newly covered clusters have the Agent installed. Deleting a rule uninstalls the Agent from every cluster the rule covered.
+
+### When an install fails
+
+Datadog retries the installation during later reconciliations. Missing-permission problems appear as an issue on the **AWS integration tile** and on the Fleet install page.
+
+<div class="alert alert-warning">
+When someone manually removes the Agent from a covered cluster, the next reconciliation reinstalls it. The rule is the source of truth. To stop coverage, change or delete the rule.
+</div>
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Uninstall the Agent
 
+{{< tabs >}}
+{{% tab "EC2" %}}
+
 Uninstalling removes the Datadog Agent, the `/etc/datadog-agent` and `/opt/datadog-agent` directories on Linux (or performs an MSI uninstall on Windows), and any IAM role or instance profile Datadog created for that instance. To uninstall, remove instances from a rule, edit the rule's query, or delete the rule.
+
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+To uninstall, remove clusters from a rule, edit the rule's query, or delete the rule. Datadog performs cleanup in this order:
+
+1. The Datadog Operator deletes the `DatadogAgent` resource it created and its dependent resources.
+1. After the Operator reports that cleanup is complete, Datadog deletes the `datadog_operator` EKS add-on that it installed.
+1. Datadog removes the Pod Identity association and scoped IAM role that it created.
+1. The AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons remain installed so you can use them with other workloads.
+1. Datadog preserves the Datadog API and application keys and their cluster-specific secrets in AWS Secrets Manager for safe reuse if the cluster is added to a rule again.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further reading
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -21,7 +21,7 @@ This page explains how Datadog installs and maintains the Agent on Amazon EC2 in
 {{< tabs >}}
 {{% tab "EC2" %}}
 
-The CloudFormation template you launch creates the following resources one time, in a single stack:
+The CloudFormation template you launch creates the following AWS resources one time, in a single stack:
 
 | Resource | Name | Purpose |
 |---|---|---|
@@ -31,7 +31,7 @@ The CloudFormation template you launch creates the following resources one time,
 | IAM role | auto-named | Lets EventBridge send events to the `datadog-agent-resource-update-intake-destination` API destination |
 | IAM role | `datadog-eventbridge-cross-region-role` | Lets other regions forward events to your primary region |
 
-Datadog creates the following resources as needed, at install time:
+Datadog creates the following AWS resources as needed, at install time:
 
 | Resource | Name | Purpose |
 |---|---|---|
@@ -46,7 +46,7 @@ Datadog does not create S3 buckets, event buses, log groups, or SSM parameters, 
 {{% /tab %}}
 {{% tab "EKS" %}}
 
-The CloudFormation template you launch creates the following resources one time, in a single stack:
+The CloudFormation template you launch creates the following AWS resources one time, in a single stack:
 
 | Resource | Name | Purpose |
 |---|---|---|
@@ -58,7 +58,7 @@ The CloudFormation template you launch creates the following resources one time,
 | AWS Marketplace subscription function and IAM role | auto-named | Accepts the one-time, account-level agreement for the Datadog Operator EKS add-on |
 | IAM permissions boundary | `datadog-instrumenter-eks-ascp-boundary` under `/datadog/instrumenter-boundaries/` | Limits the permissions available to the per-cluster credential synchronization role |
 
-Datadog creates the following resources as needed, at install time:
+Datadog creates the following AWS resources as needed, at install time:
 
 | Resource | Name | Purpose |
 |---|---|---|
@@ -68,10 +68,17 @@ Datadog creates the following resources as needed, at install time:
 | Secrets Manager secret | `/datadog/eks-instrumenter/<ACCOUNT_ID>/<CLUSTER_NAME>/application-key` | Holds the cluster-specific Datadog application key |
 | IAM role and inline policy | `dd-eks-ascp-sync-<CLUSTER_NAME>-<HASH>` and `dd-eks-instrumenter-ascp-sync-policy` | Let the credential synchronization service account read only the two cluster-specific secrets |
 | EKS Pod Identity association | `datadog-agent/datadog-ascp-sync` | Associates the credential synchronization service account with its scoped IAM role |
+
+Datadog also creates one Datadog application key per cluster with only the **Remote Configuration Read** permission.
+
+The Datadog Operator creates the following Kubernetes resources inside the cluster:
+
+| Resource | Name | Purpose |
+|---|---|---|
 | Kubernetes Secret | `datadog-agent/datadog-managed-secret` | Makes the API and application keys available to the managed Agent resources |
 | `DatadogAgent` custom resource | `datadog-agent/datadog-agent` | Defines the Agent configuration that the Datadog Operator maintains |
 
-Datadog also creates one application key per cluster with only the **Remote Configuration Read** permission. Datadog does not call the Kubernetes API during installation; the Datadog Operator creates and removes the managed resources inside the cluster.
+Datadog does not call the Kubernetes API during installation; the Datadog Operator creates and removes the managed resources inside the cluster.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -159,7 +166,7 @@ Datadog uses the same cross-account IAM role as the AWS integration and receives
 
 ### Auditing Datadog's actions
 
-Every AWS action Datadog takes appears in AWS CloudTrail. Resources created for an installation are identifiable by their names and tags: secrets use the `/datadog/eks-instrumenter/` prefix, the credential synchronization role uses the `dd-eks-ascp-sync-` prefix, and the Datadog Operator add-on includes tags that identify the installation and cluster.
+Every AWS action Datadog takes appears in AWS CloudTrail. AWS resources created for an installation are identifiable by their names and tags: secrets use the `/datadog/eks-instrumenter/` prefix, the credential synchronization role uses the `dd-eks-ascp-sync-` prefix, and the Datadog Operator add-on includes tags that identify the installation and cluster.
 
 ### How the API and application keys are handled
 
@@ -257,7 +264,7 @@ Uninstalling removes the Datadog Agent, the `/etc/datadog-agent` and `/opt/datad
 
 To uninstall, remove clusters from a rule, edit the rule's query, or delete the rule. Datadog performs cleanup in this order:
 
-1. The Datadog Operator deletes the `DatadogAgent` resource it created and its dependent resources.
+1. The Datadog Operator deletes the `DatadogAgent` custom resource it created and its dependent Kubernetes resources.
 1. After the Operator reports that cleanup is complete, Datadog deletes the `datadog_operator` EKS add-on that it installed.
 1. Datadog removes the Pod Identity association and scoped IAM role that it created.
 1. The AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons remain installed so you can use them with other workloads.

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -43,6 +43,8 @@ Before you begin, confirm the following:
 - **SSM Agent**: The [AWS Systems Manager (SSM) Agent][2] must already be present on the target instances. Datadog installs the Agent through SSM and can't install the SSM Agent for you, so instances built from custom AMIs without the SSM Agent are not eligible. Datadog flags these instances so you can address them.
 - **Supported platforms**: Linux (x86_64 and arm64) and Windows (x86_64). macOS and Windows on arm64 are not supported.
 
+[2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -95,6 +97,8 @@ Datadog uses the following permissions for the managed EKS installation path:
 
 Datadog creates the credential synchronization role with a permissions boundary. Its inline policy can read only the API and application key secrets for the selected cluster.
 
+[9]: /integrations/amazon_web_services/#aws-iam-permissions
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -116,6 +120,8 @@ For the full technical and security details, including the AWS resources Datadog
 
 {{< img src="integrations/amazon_web_services/aws-agent-installation-how-it-works.png" alt="Flowchart of the AWS Agent installation process, showing which steps happen in Datadog and which run inside your AWS account." style="width:70%;" >}}
 
+[6]: /integrations/guide/aws-agent-installation-technical-reference/
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -129,6 +135,8 @@ Agent installation is based on an **installation rule**: an AWS account paired w
 You approve one CloudFormation stack, one time, during initial setup. The stack configures the required AWS permissions and change notifications, and handles the one-time Datadog Operator AWS Marketplace agreement. After that, installations run automatically from Datadog, with no new CloudFormation template to launch for each installation.
 
 For the full technical and security details, including the resources Datadog creates, the installation mechanism, and the reconciliation model, see [How Agent installation through the AWS integration works][6].
+
+[6]: /integrations/guide/aws-agent-installation-technical-reference/
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -157,6 +165,10 @@ To install from the AWS Install Agents page:
 
 <!-- TODO(DOCS-14545): add resource-selection / Manage Agents page screenshot (AWS Install Agents page) — setup-toggle screenshot added. -->
 
+[5]: /getting_started/integrations/aws/
+[7]: https://app.datadoghq.com/integrations/amazon-web-services
+[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -173,6 +185,10 @@ You don't need to apply Kubernetes manifests or run Helm commands for this workf
 
 <!-- TODO(TON-852): Add screenshots of the Kubernetes workload toggle and EKS resource selection after the launch UI is finalized. -->
 
+[5]: /getting_started/integrations/aws/
+[7]: https://app.datadoghq.com/integrations/amazon-web-services
+[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -187,6 +203,8 @@ After the installation completes:
 - Fleet Automation lists the same Agents in the Fleet View.
 
 <!-- TODO(DOCS-14545): add expected time-to-data once confirmed. -->
+
+[3]: https://app.datadoghq.com/infrastructure
 
 {{% /tab %}}
 {{% tab "EKS" %}}
@@ -203,6 +221,9 @@ If you have Kubernetes API access, confirm that the managed resource and Agent w
 kubectl get datadogagent datadog-agent -n datadog-agent
 kubectl get pods -n datadog-agent
 ```
+
+[10]: /agent/fleet_automation/fleet_view/
+[11]: https://app.datadoghq.com/orchestration/overview/pod
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -222,6 +243,9 @@ From this page, you can:
 
 To stop coverage, update the rule. If you manually remove the Agent from a covered instance, Datadog reinstalls it on the next reconciliation. Manage Agent configuration and version upgrades through [Fleet Automation][4].
 
+[4]: /agent/fleet_automation/
+[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -234,6 +258,8 @@ To stop coverage, update or delete the installation rule. If you manually remove
 1. Datadog removes the Pod Identity association and scoped IAM role that it created.
 1. The AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons remain installed so you can use them with other workloads.
 1. Datadog preserves the Datadog API and application keys and their cluster-specific secrets in AWS Secrets Manager for safe reuse if the cluster is added to a rule again.
+
+[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -251,6 +277,8 @@ Agent installation on EC2 relies on the AWS Systems Manager (SSM) Agent, which D
 
 If installation can't complete because of missing permissions, Datadog shows a notification linking to the CloudFormation resource that needs the new permission. Update your existing stack to grant the [required permissions](#required-aws-permissions). You don't need to create a new stack.
 
+[2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
+
 {{% /tab %}}
 {{% tab "EKS" %}}
 
@@ -266,21 +294,12 @@ If installation reports an add-on error, open the cluster's **Add-ons** tab in t
 
 If installation can't complete because of missing permissions, Datadog shows a notification linking to the CloudFormation resource that needs the new permission. Update your existing stack to grant the [required permissions](#required-aws-permissions). You don't need to create a new stack.
 
+[12]: https://repost.aws/knowledge-center/eks-managed-add-on
+
 {{% /tab %}}
 {{< /tabs >}}
 
 [1]: /integrations/amazon_web_services/
-[2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
-[3]: https://app.datadoghq.com/infrastructure
-[4]: /agent/fleet_automation/
-[5]: /getting_started/integrations/aws/
-[6]: /integrations/guide/aws-agent-installation-technical-reference/
-[7]: https://app.datadoghq.com/integrations/amazon-web-services
-[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
-[9]: /integrations/amazon_web_services/#aws-iam-permissions
-[10]: /agent/fleet_automation/fleet_view/
-[11]: https://app.datadoghq.com/orchestration/overview/pod
-[12]: https://repost.aws/knowledge-center/eks-managed-add-on
 
 ## Further reading
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -123,7 +123,7 @@ Agent installation is based on an **installation rule**: an AWS account paired w
 
 1. You select the EKS clusters to cover, or opt in to all eligible clusters.
 1. Datadog resolves your selection into a list of covered clusters and records it.
-1. Datadog installs the Datadog Operator and Agent on each covered cluster, adding any missing EKS add-ons and IAM configuration automatically. It also creates or reuses cluster-specific Datadog API and application key secrets.
+1. Datadog installs the Datadog Operator and Agent on each covered cluster, adding any missing EKS add-ons and IAM configuration automatically. It also creates or reuses cluster-specific Datadog API and application key secrets in AWS Secrets Manager.
 1. Datadog keeps the covered clusters instrumented. Clusters created later aren't added until you update the rule.
 
 You approve one CloudFormation stack, one time, during initial setup. The stack configures the required AWS permissions and change notifications, and handles the one-time Datadog Operator AWS Marketplace agreement. After that, installations run automatically from Datadog, with no new CloudFormation template to launch for each installation.
@@ -229,7 +229,7 @@ Use the [AWS Install Agents page][8] to view installation status, add clusters t
 
 To stop coverage, update or delete the installation rule. If you manually remove the Agent from a covered cluster, Datadog reinstalls it on the next reconciliation. Datadog performs the following ordered cleanup for an EKS installation:
 
-1. The Datadog Operator deletes the `DatadogAgent` resource it created and its dependent resources.
+1. The Datadog Operator deletes the `DatadogAgent` custom resource it created and its dependent Kubernetes resources.
 1. After the Operator reports that cleanup is complete, Datadog deletes the `datadog_operator` EKS add-on that it installed.
 1. Datadog removes the Pod Identity association and scoped IAM role that it created.
 1. The AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons remain installed so you can use them with other workloads.

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -1,11 +1,14 @@
 ---
 title: Install the Datadog Agent through the AWS Integration
-description: "Install and manage the Datadog Agent on your Amazon EC2 instances directly from the AWS integration, without connecting to each host or running per-host scripts."
-private: true # TODO(DOCS-14545): remove at v1 rollout to publish; also add the nextlink entry under "AWS guides" in hugo/content/en/integrations/guide/_index.md at that time
+description: "Install and manage the Datadog Agent on your Amazon EC2 instances and Amazon EKS clusters directly from the AWS integration."
+private: true # TODO(DOCS-14545): remove at v1 rollout to publish
 further_reading:
 - link: "https://docs.datadoghq.com/integrations/guide/aws-agent-installation-technical-reference/"
   tag: "Documentation"
   text: "How Agent installation through the AWS integration works"
+- link: "https://docs.datadoghq.com/containers/guide/operator-eks-addon/"
+  tag: "Documentation"
+  text: "Install the Datadog Operator as an Amazon EKS add-on"
 - link: "https://docs.datadoghq.com/integrations/amazon_web_services/"
   tag: "Documentation"
   text: "AWS Integration"
@@ -25,21 +28,36 @@ further_reading:
 
 ## Overview
 
-The [AWS integration][1] collects metrics, events, and logs from Amazon CloudWatch without installing anything on your hosts. Installing the Datadog Agent adds telemetry from inside your AWS workloads that CloudWatch alone can't provide, including host-level metrics, distributed traces (APM), live processes, and detailed logs.
+The [AWS integration][1] collects metrics, events, and logs from Amazon CloudWatch without installing anything in your compute resources. Installing the Datadog Agent adds telemetry from inside your AWS workloads that CloudWatch alone can't provide, including host-level metrics, distributed traces (APM), live processes, and detailed logs.
 
-You can deploy the Datadog Agent to your Amazon EC2 instances directly from Datadog, without connecting to each host or running per-host scripts. Enable Agent installation while you set up the AWS integration, or at any time afterward.
-
-Amazon EKS is not supported.
+Deploy the Datadog Agent to Amazon EC2 instances or Amazon EKS clusters directly from Datadog. Enable Agent installation while you set up the AWS integration, or at any time afterward.
 
 ## Prerequisites
 
 Before you begin, confirm the following:
 
+{{< tabs >}}
+{{% tab "EC2" %}}
+
 - **CloudFormation access**: You can approve a CloudFormation stack in the target AWS account. Installation deploys a stack in your account, so you (or a teammate) need permission to review and create it. For the required permissions and why they're needed, see the [Required AWS permissions](#required-aws-permissions) section.
 - **SSM Agent**: The [AWS Systems Manager (SSM) Agent][2] must already be present on the target instances. Datadog installs the Agent through SSM and can't install the SSM Agent for you, so instances built from custom AMIs without the SSM Agent are not eligible. Datadog flags these instances so you can address them.
 - **Supported platforms**: Linux (x86_64 and arm64) and Windows (x86_64). macOS and Windows on arm64 are not supported.
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+- **CloudFormation access**: You can approve the Agent installation CloudFormation stack in the target AWS account. The stack adds the [required permissions](#required-aws-permissions) to the AWS integration role and configures resource-change notifications.
+- **AWS Marketplace access**: The AWS account can accept the agreement for the Datadog Operator EKS add-on. The CloudFormation setup handles this one-time, account-level agreement.
+- **Supported add-on version**: Datadog Operator EKS add-on version 0.1.31 or later is available for the cluster's AWS region and Kubernetes version.
+- **Supported clusters**: The cluster status is `ACTIVE`, all workloads run on Amazon EC2-backed nodes, and at least one node runs Linux. Additional EC2 nodes can run Linux or Windows. Clusters with EKS Fargate workloads are not supported because this installation method does not provide Agent coverage for Fargate workloads.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Required AWS permissions
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 {{% aws-agent-installation %}}
 
@@ -55,11 +73,35 @@ Datadog uses each of these permissions for a specific task:
 | `iam:CreateRole`, `iam:CreateInstanceProfile`, `iam:AddRoleToInstanceProfile`, `iam:AttachRolePolicy`, `iam:PutRolePolicy`, `iam:PassRole`, `ec2:AssociateIamInstanceProfile`, and the matching `Get` and `List` reads | Give an instance the minimum access it needs in case it does not have an IAM role: reachable by Systems Manager, and able to read its own API key secret |
 | `iam:Detach*`, `iam:Delete*`, `iam:RemoveRoleFromInstanceProfile`, `ec2:Disassociate*`, `ec2:DescribeIamInstanceProfileAssociations` | Cleanly undo the resources above when you uninstall |
 | `ecs:ListClusters`, `ecs:ListContainerInstances` | Recognize Amazon Elastic Container Service (ECS) container instances so Datadog skips them (they are handled at the cluster level) |
-| `events:PutRule`, `events:PutTargets`, `events:RemoveTargets`, `events:DeleteRule` | Set up the change notifications that let Datadog react to instance changes |
+| `events:DescribeRule`, `events:ListTargetsByRule`, `events:PutRule`, `events:PutTargets`, `events:RemoveTargets`, `events:DeleteRule` | Set up and inspect the change notifications that let Datadog react to instance changes |
 
 `iam:CreateRole` and `iam:PassRole` are the most sensitive grants. `iam:CreateRole` is restricted to role names matching `datadog-ec2-instrumenter/datadog-ssm-*` in your account, and `iam:PassRole` is further restricted to the Amazon EC2 service.
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+Agent installation requires permissions beyond the base [AWS integration IAM policy][9]. All write actions use temporary credentials for the AWS integration role. The CloudFormation stack adds the permissions; you don't need to apply a policy manually.
+
+Datadog uses the following permissions for the managed EKS installation path:
+
+| Permission | Why Datadog needs it |
+|---|---|
+| `eks:DescribeCluster` | Find the selected cluster and confirm that its status is `ACTIVE` |
+| `eks:CreateAddon`, `eks:DescribeAddon`, `eks:UpdateAddon`, `eks:DescribeUpdate`, `eks:DeleteAddon`, `eks:TagResource` | Install and manage the Datadog Operator, AWS Secrets Store CSI Driver Provider, and EKS Pod Identity Agent add-ons |
+| `eks:CreatePodIdentityAssociation`, `eks:DescribePodIdentityAssociation`, `eks:ListPodIdentityAssociations`, `eks:DeletePodIdentityAssociation` | Give the credential synchronization service account access to its scoped IAM role |
+| `secretsmanager:DescribeSecret`, `secretsmanager:CreateSecret`, `secretsmanager:TagResource` | Create or safely reuse the cluster-specific Datadog API and application key secrets |
+| `iam:GetRole`, `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`, `iam:TagRole`, `iam:DeleteRolePolicy`, `iam:DeleteRole` | Create the credential synchronization role, scope it to the cluster's API and application key secrets, pass it to EKS Pod Identity, and remove the role during uninstall |
+| `events:DescribeRule`, `events:ListTargetsByRule`, `events:PutRule`, `events:PutTargets`, `events:RemoveTargets`, `events:DeleteRule` | Set up and inspect notifications that let Datadog react to EKS cluster changes |
+
+Datadog creates the credential synchronization role with a permissions boundary. Its inline policy can read only the API and application key secrets for the selected cluster.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## How it works
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Saving a rule resolves the query into a fixed list of instances. Datadog then installs the Agent on each one, inside your own account:
 
@@ -74,9 +116,29 @@ For the full technical and security details, including the AWS resources Datadog
 
 {{< img src="integrations/amazon_web_services/aws-agent-installation-how-it-works.png" alt="Flowchart of the AWS Agent installation process, showing which steps happen in Datadog and which run inside your AWS account." style="width:70%;" >}}
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EKS clusters to cover. Saving a rule resolves the query into a fixed list of clusters. Datadog then installs the Agent on each one, inside your own account:
+
+1. You select the EKS clusters to cover, or opt in to all eligible clusters.
+1. Datadog resolves your selection into a list of covered clusters and records it.
+1. Datadog installs the Datadog Operator and Agent on each covered cluster, adding any missing EKS add-ons and IAM configuration automatically. It also creates or reuses cluster-specific Datadog API and application key secrets.
+1. Datadog keeps the covered clusters instrumented. Clusters created later aren't added until you update the rule.
+
+You approve one CloudFormation stack, one time, during initial setup. The stack configures the required AWS permissions and change notifications, and handles the one-time Datadog Operator AWS Marketplace agreement. After that, installations run automatically from Datadog, with no new CloudFormation template to launch for each installation.
+
+For the full technical and security details, including the resources Datadog creates, the installation mechanism, and the reconciliation model, see [How Agent installation through the AWS integration works][6].
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Install the Agent
 
-You can start Agent installation from two entry points, depending on how much control you want over which instances are instrumented:
+Start Agent installation from either of the following entry points, depending on how much control you want over which resources are instrumented:
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 - **AWS integration setup (install on all eligible instances)**: When you [set up the AWS integration][5], enable the Agent installation toggle on the [AWS integration page][7], shown alongside log and resource collection. The Agent installs on all eligible EC2 instances.
 - **Fleet Automation (install on specific instances)**: Open the [AWS Install Agents page][8] at any time to select the specific EC2 instances you want.
@@ -95,7 +157,29 @@ To install from the AWS Install Agents page:
 
 <!-- TODO(DOCS-14545): add resource-selection / Manage Agents page screenshot (AWS Install Agents page) — setup-toggle screenshot added. -->
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+- **AWS integration setup (install on all eligible clusters)**: When you [set up the AWS integration][5], enable Agent installation on the [AWS integration page][7], then enable the **Kubernetes** workload. Datadog installs the Datadog Operator add-on and Agent on eligible EKS clusters.
+- **Fleet Automation (install on specific clusters)**: Open the [AWS Install Agents page][8] to select specific EKS clusters.
+
+To install from the AWS Install Agents page:
+
+1. Opt in to all eligible clusters, or select specific EKS clusters from the resource list.
+1. Review the generated CloudFormation stack, then continue to AWS and create it. The setup configures the required permissions, change notifications, and AWS Marketplace agreement.
+1. Return to Datadog. The installation proceeds automatically, and Datadog reports progress for each selected cluster.
+
+You don't need to apply Kubernetes manifests or run Helm commands for this workflow.
+
+<!-- TODO(TON-852): Add screenshots of the Kubernetes workload toggle and EKS resource selection after the launch UI is finalized. -->
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Verify the installation
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 After the installation completes:
 
@@ -104,7 +188,29 @@ After the installation completes:
 
 <!-- TODO(DOCS-14545): add expected time-to-data once confirmed. -->
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+After Datadog reports that the installation is active:
+
+- Confirm that the `datadog_operator`, `aws-secrets-store-csi-driver-provider`, and `eks-pod-identity-agent` add-ons are active in Amazon EKS.
+- Open [Fleet View][10], switch to the Kubernetes view, and find the cluster.
+- Open [Kubernetes Explorer][11] and confirm that the expected cluster, nodes, and workloads appear.
+
+If you have Kubernetes API access, confirm that the managed resource and Agent workloads exist:
+
+```shell
+kubectl get datadogagent datadog-agent -n datadog-agent
+kubectl get pods -n datadog-agent
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Manage installed Agents
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 Use the [AWS Install Agents page][8] in Fleet Automation to manage the Agents you've installed through the AWS integration.
 
@@ -116,7 +222,26 @@ From this page, you can:
 
 To stop coverage, update the rule. If you manually remove the Agent from a covered instance, Datadog reinstalls it on the next reconciliation. Manage Agent configuration and version upgrades through [Fleet Automation][4].
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+Use the [AWS Install Agents page][8] to view installation status, add clusters to an installation rule, or remove clusters from coverage.
+
+To stop coverage, update or delete the installation rule. If you manually remove the Agent from a covered cluster, Datadog reinstalls it on the next reconciliation. Datadog performs the following ordered cleanup for an EKS installation:
+
+1. The Datadog Operator deletes the `DatadogAgent` resource it created and its dependent resources.
+1. After the Operator reports that cleanup is complete, Datadog deletes the `datadog_operator` EKS add-on that it installed.
+1. Datadog removes the Pod Identity association and scoped IAM role that it created.
+1. The AWS Secrets Store CSI Driver Provider and EKS Pod Identity Agent add-ons remain installed so you can use them with other workloads.
+1. Datadog preserves the Datadog API and application keys and their cluster-specific secrets in AWS Secrets Manager for safe reuse if the cluster is added to a rule again.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Troubleshooting
+
+{{< tabs >}}
+{{% tab "EC2" %}}
 
 ### The SSM Agent is not present on an EC2 instance
 
@@ -126,15 +251,37 @@ Agent installation on EC2 relies on the AWS Systems Manager (SSM) Agent, which D
 
 If installation can't complete because of missing permissions, Datadog shows a notification linking to the CloudFormation resource that needs the new permission. Update your existing stack to grant the [required permissions](#required-aws-permissions). You don't need to create a new stack.
 
+{{% /tab %}}
+{{% tab "EKS" %}}
+
+### A required EKS add-on is incompatible or unhealthy
+
+Datadog installs the `datadog_operator` add-on and installs or reuses the `aws-secrets-store-csi-driver-provider` and `eks-pod-identity-agent` prerequisite add-ons. Each add-on must reach the `ACTIVE` state before Agent installation can complete.
+
+If the `aws-secrets-store-csi-driver-provider` add-on is already installed, its configuration must set `secrets-store-csi-driver.syncSecret.enabled` to `true`. Datadog doesn't modify the configuration of an existing add-on.
+
+If installation reports an add-on error, open the cluster's **Add-ons** tab in the Amazon EKS console, select the affected add-on, and review its **Health issues**. Resolve the reported issue or enable secret synchronization. Datadog retries the installation during the next reconciliation. For more information, see [FAQs: Amazon EKS add-ons][12] in the AWS documentation.
+
+### A permission or IAM error occurs
+
+If installation can't complete because of missing permissions, Datadog shows a notification linking to the CloudFormation resource that needs the new permission. Update your existing stack to grant the [required permissions](#required-aws-permissions). You don't need to create a new stack.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+[1]: /integrations/amazon_web_services/
+[2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
+[3]: https://app.datadoghq.com/infrastructure
+[4]: /agent/fleet_automation/
+[5]: /getting_started/integrations/aws/
+[6]: /integrations/guide/aws-agent-installation-technical-reference/
+[7]: https://app.datadoghq.com/integrations/amazon-web-services
+[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws
+[9]: /integrations/amazon_web_services/#aws-iam-permissions
+[10]: /agent/fleet_automation/fleet_view/
+[11]: https://app.datadoghq.com/orchestration/overview/pod
+[12]: https://repost.aws/knowledge-center/eks-managed-add-on
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-[1]: https://docs.datadoghq.com/integrations/amazon_web_services/
-[2]: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html
-[3]: https://app.datadoghq.com/infrastructure
-[4]: https://docs.datadoghq.com/agent/fleet_automation/
-[5]: https://docs.datadoghq.com/getting_started/integrations/aws/
-[6]: https://docs.datadoghq.com/integrations/guide/aws-agent-installation-technical-reference/
-[7]: https://app.datadoghq.com/integrations/amazon-web-services
-[8]: https://app.datadoghq.com/fleet/install-agent/latest?platform=aws


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Tracks TON-852.

Adds Amazon EKS support to the existing AWS integration Agent installation documentation. The updates:

- Add parallel EC2 and EKS tabs to the setup and technical-reference pages.
- Document EKS prerequisites, IAM permissions, managed resources, installation, verification, reconciliation, uninstall behavior, and troubleshooting.
- Add EKS Agent installation entry points to the AWS getting-started page and AWS guides index.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- The branch follows the required name/description convention.
- Run `/review` for the automated documentation check.

### AI assistance

Used Codex to research source behavior, draft and revise the documentation, and check EC2/EKS parity and technical accuracy.

### Additional notes

