### PR TITLE
[MLOB-8127] Document Java support for Agent Observability trace sampling

### DIFF
--- a/hugo/content/en/llm_observability/instrument/sdk.md
+++ b/hugo/content/en/llm_observability/instrument/sdk.md
@@ -176,6 +176,10 @@ You can supply the following parameters as environment variables (for example, `
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
+`DD_LLMOBS_SAMPLE_RATE` or `dd.llmobs.sample.rate`
+: optional - _float_ - **default**: `1.0`
+<br />The fraction of traces retained by Agent Observability. Requires `dd-trace-java` 1.66.0 or later. See [Trace sampling](#trace-sampling).
+
 `DD_API_KEY` or `dd.api.key`
 : optional - _string_
 <br />Your Datadog API key. Only required if you are not using the Datadog Agent.
@@ -319,7 +323,7 @@ After installing the SDK and running your application you should expect to see s
 
 ## Trace sampling
 
-<div class="alert alert-info">Trace sampling is available in the Python SDK (<code>ddtrace</code> 4.12.0 or later) and the Node.js SDK (<code>dd-trace</code> 5.110.0 or later). The Java SDK does not support trace sampling.</div>
+<div class="alert alert-info">Trace sampling is available in the Python SDK (<code>ddtrace</code> 4.12.0 or later), the Node.js SDK (<code>dd-trace</code> 5.110.0 or later), and the Java SDK (<code>dd-trace-java</code> 1.66.0 or later).</div>
 
 Trace sampling sets the fraction of traces that Agent Observability retains. Because Agent Observability billing is based on the volume of spans you send, setting a sample rate is one way to control your Agent Observability cost. The SDK makes the sampling decision on the root span and applies it to all of that root span's child spans, including spans created in downstream services through [distributed tracing](#distributed-tracing).
 
@@ -327,8 +331,8 @@ Sampling does not affect your [Agent Observability metrics](/llm_observability/i
 
 Configure the sample rate through either of two mechanisms:
 
-- **Environment variable** (`DD_LLMOBS_SAMPLE_RATE`): applies to both [command-line setup](#command-line-setup) and [in-code setup](#in-code-setup).
-- **In-code parameter** (`sample_rate` in Python, `sampleRate` in Node.js): passed to `LLMObs.enable()` in Python, or under `llmobs` in Node.js, when you enable the SDK with [in-code setup](#in-code-setup). When set, it takes precedence over `DD_LLMOBS_SAMPLE_RATE`.
+- **Environment variable** (`DD_LLMOBS_SAMPLE_RATE`): applies to both [command-line setup](#command-line-setup) and [in-code setup](#in-code-setup). In Java, the `dd.llmobs.sample.rate` system property sets the same value.
+- **In-code parameter** (`sample_rate` in Python, `sampleRate` in Node.js): passed to `LLMObs.enable()` in Python, or under `llmobs` in Node.js, when you enable the SDK with [in-code setup](#in-code-setup). When set, it takes precedence over `DD_LLMOBS_SAMPLE_RATE`. The Java SDK has no in-code equivalent.
 
 The sample rate is a float between `0.0` (retain no traces) and `1.0` (retain all traces). The default is `1.0`. Out-of-range values are ignored.
 
@@ -371,6 +375,27 @@ const tracer = require('dd-trace').init({
 
 const llmobs = tracer.llmobs;
 {{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Java" %}}
+Set the sample rate with the environment variable:
+
+{{< code-block lang="shell" >}}
+DD_LLMOBS_SAMPLE_RATE=0.5 \
+java -javaagent:path/to/your/dd-trace-java-jar/dd-java-agent-SNAPSHOT.jar \
+-Ddd.service=my-app -Ddd.llmobs.enabled=true -Ddd.llmobs.ml.app=<YOUR_ML_APP_NAME> \
+-jar path/to/your/app.jar
+{{< /code-block >}}
+
+Or set the equivalent `dd.llmobs.sample.rate` system property:
+
+{{< code-block lang="shell" >}}
+java -javaagent:path/to/your/dd-trace-java-jar/dd-java-agent-SNAPSHOT.jar \
+-Ddd.service=my-app -Ddd.llmobs.enabled=true -Ddd.llmobs.ml.app=<YOUR_ML_APP_NAME> \
+-Ddd.llmobs.sample.rate=0.5 -jar path/to/your/app.jar
+{{< /code-block >}}
+
+The Java SDK derives the sampling decision from the trace ID, so services configured with the same sample rate reach the same decision for a given trace. Set the same rate across all services in a distributed trace to keep each trace whole.
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/hugo/content/en/llm_observability/instrument/sdk.md
+++ b/hugo/content/en/llm_observability/instrument/sdk.md
@@ -394,8 +394,6 @@ java -javaagent:path/to/your/dd-trace-java-jar/dd-java-agent-SNAPSHOT.jar \
 -Ddd.service=my-app -Ddd.llmobs.enabled=true -Ddd.llmobs.ml.app=<YOUR_ML_APP_NAME> \
 -Ddd.llmobs.sample.rate=0.5 -jar path/to/your/app.jar
 {{< /code-block >}}
-
-The Java SDK derives the sampling decision from the trace ID, so services configured with the same sample rate reach the same decision for a given trace. Set the same rate across all services in a distributed trace to keep each trace whole.
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes MLOB-8127

The Java SDK now supports Agent Observability trace sampling as of `dd-trace-java` 1.66.0. The Trace sampling section stated that the Java SDK did not support it, so this PR updates that page.

Changes to `llm_observability/instrument/sdk.md`:

- Update the Trace sampling availability callout to include the Java SDK (`dd-trace-java` 1.66.0 or later), replacing the statement that Java does not support trace sampling.
- Add a **Java** tab to the Trace sampling section showing both the `DD_LLMOBS_SAMPLE_RATE` environment variable and the `dd.llmobs.sample.rate` system property, and noting that services in a distributed trace should share the same rate.
- Note that Java accepts the system property, and that Java has no in-code equivalent of the Python `sample_rate` / Node.js `sampleRate` parameter.
- Add `DD_LLMOBS_SAMPLE_RATE` or `dd.llmobs.sample.rate` to the Java environment variables and system properties reference list.

No changes to the Python or Node.js content, and no change to the existing description of sampling behavior or its interaction with metrics.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code. The version number, the configuration key names, the default value, and the out-of-range fallback behavior were each read from the `dd-trace-java` source and release tags rather than assumed.

### Additional notes

The sample rate default (`1.0`) and the valid range (`0.0`–`1.0`, out-of-range values falling back to `1.0`) match the behavior already documented for Python and Node.js, so the shared prose above the tabs needed no changes.
