### PR TITLE
Test Parallelization: Document new JavaScript framework support

### DIFF
--- a/hugo/content/en/tests/test_parallelization/_index.md
+++ b/hugo/content/en/tests/test_parallelization/_index.md
@@ -23,7 +23,9 @@ Test Parallelization is supported for the following language and frameworks:
 | -------- | ---------- | ----------------------- |
 | Ruby     | RSpec, Minitest | `datadog-ci` gem `1.31.0` or later |
 | Python   | pytest | `ddtrace` package `4.11.0` or later |
-| JavaScript | Jest | `dd-trace` package `5.111.0` or later for `v5` and `6.0.0` or later for `v6` |
+| JavaScript | Cucumber.js, Cypress, Jest, Mocha, Playwright, Vitest | `dd-trace` package `5.111.0` or later for `v5` and `6.0.0` or later for `v6` |
+
+For JavaScript, `ddtest` requires Cypress 12 or later, Mocha 8 or later, Playwright 1.18 or later, and Vitest 1.6 or later. Cucumber.js support is tested with versions 7 through 13. These frameworks require `ddtest` 1.6.0 or later. Your framework version must also meet the [`dd-trace` compatibility requirements][4].
 
 ## How it works
 
@@ -47,3 +49,4 @@ For single-node and multi-node examples, see [Set Up Test Parallelization][3].
 [1]: /tests/test_impact_analysis/
 [2]: /tests/setup/
 [3]: /tests/test_parallelization/setup/
+[4]: /tests/setup/javascript/#compatibility

--- a/hugo/content/en/tests/test_parallelization/best_practices.md
+++ b/hugo/content/en/tests/test_parallelization/best_practices.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Optimize the planning step
 
-Test Parallelization adds a planning step that discovers tests before execution. For example, RSpec projects use dry-run discovery, pytest projects use collection, and Jest projects use `--listTests`. Keep this step lightweight so the time saved by parallel execution is not offset by planning overhead.
+Test Parallelization adds a planning step that discovers tests before execution. For example, RSpec projects use dry-run discovery, pytest projects use collection, and JavaScript projects use framework-native file discovery. Keep this step lightweight so the time saved by parallel execution is not offset by planning overhead.
 
 ### Preinstall system dependencies with Docker
 
@@ -126,7 +126,15 @@ For test discovery, `ddtest` reads `testpaths` and `python_files` from `pytest.i
 
 During discovery, `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED` is set to `1`. Use this variable to skip expensive setup code during planning, similar to [skipping database setup during discovery](#skip-database-setup-during-discovery).
 
-## Configure Jest
+## Configure JavaScript frameworks
+
+For JavaScript, `ddtest` plans and distributes test files, not individual tests. It uses the local framework executable under `node_modules/.bin` when available and otherwise uses `npx`.
+
+Use `--command` when your project invokes the framework through another package manager, a wrapper, a profile, or a non-default configuration. The command must invoke the selected framework directly. Do not include a `--` separator. For Jest, Vitest, Mocha, and Cypress, omit test files because `ddtest` provides the files assigned to each worker. Cucumber.js paths and Playwright positional filters can restrict discovery, but `ddtest` replaces them during execution.
+
+`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. Ensure `dd-trace` is resolvable from the project where `ddtest` runs, and complete the [Test Optimization setup for your framework][1].
+
+### Jest
 
 `ddtest` runs Jest through the local `node_modules/.bin/jest` executable when it exists, or through `npx jest` otherwise. Use `--command` when your project runs Jest through a package manager or wrapper:
 
@@ -134,11 +142,57 @@ During discovery, `DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED` is set to `1`. Use th
 bin/ddtest run --platform javascript --framework jest --command "pnpm jest --runInBand"
 {{< /code-block >}}
 
-Do not include test files or a `--` separator in the command. `ddtest` appends the file list and Jest flags itself.
-
-`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. Ensure `dd-trace` is resolvable from the project where `ddtest` runs.
-
 `ddtest` discovers and splits test files and suites, not individual Jest tests.
+
+### Vitest
+
+Vitest 1.6 or later is required. Use `--command` when your project uses a package manager or Vitest projects:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework vitest --command "pnpm exec vitest run --project unit*"
+{{< /code-block >}}
+
+The command must invoke Vitest directly. During planning, `ddtest` changes the `run` subcommand to `list --filesOnly --json` on Vitest 2.0 or later. On Vitest 1.6, `ddtest` uses Vitest's config-aware discovery API. During execution, it appends the selected test files.
+
+### Mocha
+
+Mocha 8 or later is required. Use a command that invokes Mocha directly when passing framework options:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework mocha --command "pnpm exec mocha --parallel"
+{{< /code-block >}}
+
+`ddtest` reads Mocha's effective configuration without loading test modules during discovery. During execution, it replaces configured `spec` inputs with the files assigned to each worker and preserves shared `--file` setup.
+
+### Cypress
+
+Cypress 12 or later is required. Use a command that invokes Cypress directly when selecting component testing, an alternate project root, or a custom configuration file:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework cypress --command "pnpm exec cypress run --project apps/web --component"
+{{< /code-block >}}
+
+`ddtest` asks Cypress to resolve its effective configuration during planning and replaces any command-level `--spec` value with the files assigned to each worker during execution. Cypress calls the project's `setupNodeEvents` function while resolving configuration, so side effects in that function also occur during planning. Cypress requires [manual Test Optimization instrumentation][1].
+
+### Playwright
+
+Playwright 1.18 or later is required. If you use `dd-trace` v6, Playwright 1.38 or later is required. Use a command that invokes `playwright test` directly when selecting a configuration, projects, or other Playwright options:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework playwright --command "pnpm exec playwright test --config apps/web/playwright.config.ts --project chromium"
+{{< /code-block >}}
+
+Do not include Playwright's `--shard` option. `ddtest` asks Playwright to list tests with its effective configuration, deduplicates files shared by multiple projects, and passes each worker only its assigned files. Configuration, project, grep, and positional filters are preserved during discovery. Playwright loads test modules and their top-level code while listing tests, but does not run test bodies. During execution, `ddtest` preserves configuration, project, grep, reporter, retry, and worker options, replaces positional filters, and removes interactive UI options because workers run non-interactively. Playwright remains responsible for running dependency and teardown projects associated with the selected projects.
+
+### Cucumber.js
+
+`ddtest` is tested with `@cucumber/cucumber` versions 7 through 13. Use a command that invokes `cucumber-js` directly when selecting profiles or passing Cucumber filters:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework cucumber --command "pnpm exec cucumber-js --profile ci --tags=@smoke"
+{{< /code-block >}}
+
+During planning, `ddtest` performs a serial dry run and uses Cucumber Messages to discover only feature files that contain scenarios selected by the effective paths, profile, tags, and name filters. Cucumber loads support code, but does not execute step or hook bodies. During execution, `ddtest` replaces positional feature paths and rerun files in `--command` with the files assigned to each worker while preserving Cucumber options. Prefer tag or name filters over scenario line selectors because `ddtest` plans at feature-file granularity.
 
 ## Configure Minitest in non-Rails projects
 
@@ -153,3 +207,5 @@ end
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tests/setup/javascript/

--- a/hugo/content/en/tests/test_parallelization/best_practices.md
+++ b/hugo/content/en/tests/test_parallelization/best_practices.md
@@ -132,7 +132,7 @@ For JavaScript, `ddtest` plans and distributes test files, not individual tests.
 
 Use `--command` when your project invokes the framework through another package manager, a wrapper, a profile, or a non-default configuration. The command must invoke the selected framework directly. Do not include a `--` separator. For Jest, Vitest, Mocha, and Cypress, omit test files because `ddtest` provides the files assigned to each worker. Cucumber.js paths and Playwright positional filters can restrict discovery, but `ddtest` replaces them during execution.
 
-`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. Ensure `dd-trace` is resolvable from the project where `ddtest` runs, and complete the [Test Optimization setup for your framework][1].
+`ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present. The `dd-trace` package must be resolvable from the project where `ddtest` runs. Complete the [Test Optimization setup for your framework][1].
 
 ### Jest
 
@@ -192,7 +192,7 @@ Do not include Playwright's `--shard` option. `ddtest` asks Playwright to list t
 bin/ddtest run --platform javascript --framework cucumber --command "pnpm exec cucumber-js --profile ci --tags=@smoke"
 {{< /code-block >}}
 
-During planning, `ddtest` performs a serial dry run and uses Cucumber Messages to discover only feature files that contain scenarios selected by the effective paths, profile, tags, and name filters. Cucumber loads support code, but does not execute step or hook bodies. During execution, `ddtest` replaces positional feature paths and rerun files in `--command` with the files assigned to each worker while preserving Cucumber options. Prefer tag or name filters over scenario line selectors because `ddtest` plans at feature-file granularity.
+During planning, `ddtest` performs a serial dry run and uses Cucumber Messages to discover feature files. It includes only files containing scenarios selected by the effective paths, profile, tags, and name filters. Cucumber loads support code, but does not execute step or hook bodies. During execution, `ddtest` replaces positional feature paths and rerun files in `--command` with the files assigned to each worker while preserving Cucumber options. Prefer tag or name filters over scenario line selectors because `ddtest` plans at feature-file granularity.
 
 ## Configure Minitest in non-Rails projects
 

--- a/hugo/content/en/tests/test_parallelization/configuration.md
+++ b/hugo/content/en/tests/test_parallelization/configuration.md
@@ -27,13 +27,13 @@ Most `ddtest` settings can be passed as a CLI flag or as an environment variable
 : Test framework.<br/>
 **CLI flag:** `--framework`<br/>
 **Default:** `rspec`<br/>
-**Supported values:** `rspec`, `minitest`, `pytest`, `jest`
+**Supported values:** `rspec`, `minitest`, `pytest`, `cucumber`, `cypress`, `jest`, `mocha`, `playwright`, `vitest`
 
 `DD_TEST_OPTIMIZATION_RUNNER_COMMAND`
-: Overrides the default test command. `ddtest` appends selected test files and framework-specific flags to the command. Supported for Ruby, JavaScript, and Python. Python support requires ddtest 1.7.0 or later. For ddtest versions prior to 1.7.0 with pytest, the command cannot be changed. Pass extra flags with `PYTEST_ADDOPTS`. For more information, see [Custom test commands](#custom-test-commands).<br/>
+: Overrides the default test command. `ddtest` appends selected test files and framework-specific flags to the command. Supported for all frameworks. Python support requires ddtest 1.7.0 or later. For ddtest versions prior to 1.7.0 with pytest, the command cannot be changed. Pass extra flags with `PYTEST_ADDOPTS`. For more information, see [Custom test commands](#custom-test-commands).<br/>
 **CLI flag:** `--command`<br/>
 **Default:** Empty<br/>
-**Example:** `bundle exec rspec --profile`, `pnpm jest --runInBand`, `pytest`
+**Example:** `bundle exec rspec --profile`, `pnpm exec mocha --parallel`, `pytest`
 
 `DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM`
 : Minimum CI node or worker count `ddtest` considers when planning.<br/>
@@ -78,7 +78,7 @@ Most `ddtest` settings can be passed as a CLI flag or as an environment variable
 **Example:** `DB_NAME=testdb{{nodeIndex}}_{{workerIndex}};FIXTURE=fixture{{nodeIndex}}`
 
 `DD_TEST_OPTIMIZATION_RUNNER_TESTS_LOCATION`
-: Glob pattern used to discover test files. Defaults to `spec/**/*_spec.rb` for RSpec, `test/**/*_test.rb` for Minitest, pytest configuration (`testpaths` and `python_files`) or `**/{test_*,*_test}.py` for pytest, and Jest configuration or Jests's default test matching.<br/>
+: Glob pattern used to discover test files. Defaults to `spec/**/*_spec.rb` for RSpec, `test/**/*_test.rb` for Minitest, pytest configuration (`testpaths` and `python_files`) or `**/{test_*,*_test}.py` for pytest, and the effective configuration or default test matching for each JavaScript framework.<br/>
 **CLI flag:** `--tests-location`<br/>
 **Alias:** `KNAPSACK_PRO_TEST_FILE_PATTERN`<br/>
 **Default:** Framework default<br/>
@@ -148,19 +148,25 @@ If no split can meet the target, `ddtest` logs a warning. It selects the split w
 
 ## Custom test commands
 
-For Ruby frameworks and Jest, use `--command` to override the default test command:
+Use `--command` to override the default test command for any supported framework:
 
 {{< code-block lang="bash" >}}
 bin/ddtest run --platform ruby --framework rspec --command "bin/integration-tests"
 {{< /code-block >}}
 
-When using `--command`, do not include test files in the command. `ddtest` appends test files and framework-specific flags to the command.
+For Ruby, Python, Jest, Vitest, Mocha, and Cypress, do not include test files in the command. `ddtest` provides the files assigned to each worker. Cucumber.js paths and Playwright positional filters can restrict discovery, but `ddtest` replaces them with the files assigned to the worker during execution.
 
 Do not include the `--` separator in `--command`. If the command contains `--`, `ddtest` emits a warning and removes the separator and everything after it.
 
 For pytest, `ddtest` runs `python -m pytest <files>` by default. For versions 1.7.0 and later, set `--command` to override the base command. For example, `--command pytest` runs the `pytest` console script instead of `python -m pytest`. `ddtest` runs `<command> <files>` and does not add `-m pytest`. To pass extra pytest flags without changing the base command, use `PYTEST_ADDOPTS`. `ddtest` appends `--ddtrace` to `PYTEST_ADDOPTS` automatically so the `ddtrace` pytest plugin loads without changing your pytest config.
 
-For Jest, `ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless it is already present, so the `dd-trace` package must be installed in the project where `ddtest` runs.
+For JavaScript, the custom command must invoke the selected framework directly. Package manager and executable wrappers are supported. For example:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework mocha --command "pnpm exec mocha --parallel"
+{{< /code-block >}}
+
+`ddtest` preserves supported framework options and replaces inputs that conflict with its assigned test files. See [Test Parallelization best practices](/tests/test_parallelization/best_practices/#configure-javascript-frameworks) for framework-specific examples and constraints.
 
 ## Pytest test discovery
 
@@ -172,19 +178,22 @@ For pytest, `ddtest` discovers test files using this priority:
 
 Pytest does not have an equivalent to RSpec's pattern flag, so `ddtest` resolves the pattern to explicit file paths before invoking the configured pytest command. The default is `python -m pytest`. For versions 1.7.0 and later, `--command` overrides it.
 
-## Jest test discovery and instrumentation
+## JavaScript test discovery and instrumentation
 
-For Jest, `ddtest` discovers test files with Jest's own `--listTests` command. It uses this priority:
+JavaScript support uses suite-level Test Impact Analysis. `ddtest` plans, skips, and distributes test files rather than individual tests. It uses each framework's native configuration during discovery:
 
-1. `--command` when set, with `--listTests` appended.
-2. The local executable `node_modules/.bin/jest` when present.
-3. `npx jest`.
+| Framework | Discovery behavior | Execution behavior |
+| --------- | ------------------ | ------------------ |
+| Cucumber.js | Performs a serial dry run and uses Cucumber Messages to identify feature files selected by paths, profiles, tags, and name filters. | Replaces positional paths and rerun files with the feature files assigned to the worker. |
+| Cypress | Resolves the effective Cypress project and configuration, including the testing type and spec pattern. | Replaces `--spec` with the spec files assigned to the worker. |
+| Jest | Runs Jest with `--listTests`. | Appends `--runTestsByPath` and the files assigned to the worker. |
+| Mocha | Loads Mocha's effective configuration and resolves its `spec` inputs. | Replaces configured `spec` inputs with the files assigned to the worker. |
+| Playwright | Runs `playwright test --list` with a `ddtest` reporter, preserves selection options and positional filters, and deduplicates files included in multiple projects. | Replaces positional filters with exact file filters for the files assigned to the worker and removes `--shard` and interactive UI options. |
+| Vitest | Uses native file listing for Vitest 2.0 or later and a config-aware fallback for Vitest 1.6. | Runs Vitest with the files assigned to the worker. |
 
-Jest uses its own configuration and default test matching for `--listTests`. When `--tests-location` is set, `ddtest` filters the file list returned by Jest after discovery. It does not pass `--tests-location` as Jest's `--testMatch`.
+By default, `ddtest` uses the framework executable under `node_modules/.bin` when it is available and otherwise runs the framework through `npx`. Use `--command` for package managers, wrappers, profiles, projects, and other framework options. `--tests-location` and `--tests-exclude-pattern` further limit the discovered files.
 
-Jest support uses suite-level Test Impact Analysis. `ddtest` works with test files and suites, not individual Jest tests, and executes selected files with `--runTestsByPath`.
-
-During execution, `ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` for worker processes unless `NODE_OPTIONS` already loads `dd-trace/ci/init`.
+During execution, `ddtest` prepends `-r dd-trace/ci/init` to `NODE_OPTIONS` unless it is already present. For Vitest, it also imports `dd-trace/register.js`. During discovery, `ddtest` removes these preloads so that listing tests does not produce test results.
 
 ## Worker environment variables
 

--- a/hugo/content/en/tests/test_parallelization/setup.md
+++ b/hugo/content/en/tests/test_parallelization/setup.md
@@ -23,7 +23,7 @@ Before setting up Test Parallelization:
 - Set up [Test Optimization][1].
 - For Ruby: use the `datadog-ci` gem version `1.31.0` or later.
 - For Python: use the `ddtrace` package version `4.11.0` or later and `pytest`.
-- For JavaScript: use the `dd-trace` package version `5.111.0` or later for `v5` or `v6.0.0` or later for `v6`, Node.js, and Jest.
+- For JavaScript: use the `dd-trace` package version `5.111.0` or later for `v5` or `v6.0.0` or later for `v6`, Node.js, and a [supported framework version][8]. Cucumber.js, Cypress, Mocha, Playwright, and Vitest require `ddtest` 1.6.0 or later.
 - Enable [Test Impact Analysis][2] for the test service when you want Test Parallelization to split only the tests affected by a code change.
 
 ## Concepts
@@ -95,7 +95,7 @@ bin/ddtest plan \
   --max-parallelism 8
 {{< /code-block >}}
 
-`--platform` identifies the language platform, and `--framework` identifies the test framework. Supported combinations include `ruby` with `rspec` or `minitest`, `python` with `pytest`, and `javascript` with `jest`. For all supported values and defaults, see [Configuration][4].
+`--platform` identifies the language platform, and `--framework` identifies the test framework. Supported combinations include `ruby` with `rspec` or `minitest`, `python` with `pytest`, and `javascript` with `cucumber`, `cypress`, `jest`, `mocha`, `playwright`, or `vitest`. For all supported values and defaults, see [Configuration][4].
 
 Planning discovers tests, retrieves test duration and Test Impact Analysis data, and chooses a parallelism level. It does not execute tests. The generated `.testoptimization/` directory contains the test files and splits selected for execution.
 
@@ -554,7 +554,7 @@ workflows:
 
 {{< collapse-content title="JavaScript" level="h3" >}}
 
-Use the same plan and test job structure as the Ruby and Python examples. Configure the runner and setup steps for Jest.
+Use the same plan and test job structure as the Ruby and Python examples. Set `DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK` to `cucumber`, `cypress`, `jest`, `mocha`, `playwright`, or `vitest`. The following examples use Jest; replace `jest` with the framework for your test suite.
 
 {{< tabs >}}
 {{% tab "GitHub Actions" %}}
@@ -638,7 +638,7 @@ Keep the `ddtest` download, plan, cache, and continuation steps from the CircleC
 {{% /tab %}}
 {{< /tabs >}}
 
-`ddtest` prepends `NODE_OPTIONS=-r dd-trace/ci/init` for Jest worker processes, so the project dependencies installed before `ddtest plan` must include `dd-trace`.
+`ddtest` prepends `NODE_OPTIONS=-r dd-trace/ci/init` for JavaScript worker processes, so the project dependencies installed before `ddtest plan` must include `dd-trace`. This does not replace the framework-specific [Test Optimization setup][8]. For example, Cypress requires manual instrumentation in its configuration file.
 
 {{< /collapse-content >}}
 
@@ -653,3 +653,4 @@ Keep the `ddtest` download, plan, cache, and continuation steps from the CircleC
 [5]: /tests/test_parallelization/configuration/#plan-artifacts
 [6]: /tests/explorer/
 [7]: /continuous_integration/explorer/
+[8]: /tests/setup/javascript/

--- a/hugo/content/en/tests/test_parallelization/troubleshooting.md
+++ b/hugo/content/en/tests/test_parallelization/troubleshooting.md
@@ -79,7 +79,12 @@ For Cucumber.js, Cypress, Mocha, Playwright, and Vitest, the command must invoke
 bin/ddtest run --platform javascript --framework playwright --command "pnpm exec playwright test --project chromium"
 {{< /code-block >}}
 
-If a custom JavaScript command is accepted but runs an unexpected selection, check for framework inputs that `ddtest` replaces intentionally: positional paths and rerun files for Cucumber.js, `--spec` for Cypress, configured `spec` inputs for Mocha, and `--shard` or interactive UI options for Playwright.
+If a custom JavaScript command runs an unexpected selection, check the framework inputs that `ddtest` replaces:
+
+- Cucumber.js positional paths and rerun files
+- Cypress `--spec`
+- Mocha configured `spec` inputs
+- Playwright `--shard` and interactive UI options
 
 ## Further reading
 

--- a/hugo/content/en/tests/test_parallelization/troubleshooting.md
+++ b/hugo/content/en/tests/test_parallelization/troubleshooting.md
@@ -59,7 +59,7 @@ end
 
 ## Custom commands do not run the expected files
 
-When using `--command`, do not include test files or the `--` separator in the command. `ddtest` appends the selected test files itself.
+Do not include the `--` separator in a custom command. For Ruby, Python, Jest, Vitest, Mocha, and Cypress, omit test files because `ddtest` provides the files assigned to each worker. Cucumber.js paths and Playwright positional filters can restrict discovery, but `ddtest` replaces them during execution.
 
 Incorrect:
 
@@ -72,6 +72,14 @@ Correct:
 {{< code-block lang="bash" >}}
 bin/ddtest run --platform ruby --framework rspec --command "bundle exec rspec"
 {{< /code-block >}}
+
+For Cucumber.js, Cypress, Mocha, Playwright, and Vitest, the command must invoke the selected framework directly. Package manager wrappers are supported. For example:
+
+{{< code-block lang="bash" >}}
+bin/ddtest run --platform javascript --framework playwright --command "pnpm exec playwright test --project chromium"
+{{< /code-block >}}
+
+If a custom JavaScript command is accepted but runs an unexpected selection, check for framework inputs that `ddtest` replaces intentionally: positional paths and rerun files for Cucumber.js, `--spec` for Cypress, configured `spec` inputs for Mocha, and `--shard` or interactive UI options for Playwright.
 
 ## Further reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Test Parallelization documentation for the JavaScript framework support shipped in ddtest v1.6.0.

- Adds Cucumber.js, Cypress, Mocha, Playwright, and Vitest to the compatibility and configuration documentation.
- Documents framework and ddtest version requirements.
- Generalizes the JavaScript CI setup beyond Jest.
- Explains framework-native discovery, suite-level planning, instrumentation, custom commands, and file-selection behavior.
- Adds framework-specific best practices and troubleshooting guidance.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Used Codex to research the recent ddtest releases and implementation, draft the documentation updates, and run consistency checks.

