### PR TITLE
Document Agent Console permissions

### DIFF
--- a/hugo/content/en/ai_agents_console/_index.md
+++ b/hugo/content/en/ai_agents_console/_index.md
@@ -34,6 +34,17 @@ Agent Console supports the following coding agents:
 | [GitHub Copilot][4] | GitHub's AI-powered code completion tool |
 
 
+## Permissions
+
+Access to Agent Console is controlled by two dedicated [permissions][9]:
+
+- **Agent Console Read**: view Agent Console.
+- **Agent Console Write**: create, edit, and delete Agent Console configurations.
+
+Roles that already have Agent Observability read or write access receive the matching Agent Console permission, so existing access is preserved. Administrators can then remove an Agent Console permission from a role without changing that role's Agent Observability access.
+
+<div class="alert alert-warning">If you manage custom roles with Terraform, add the <strong>Agent Console Read</strong> and <strong>Agent Console Write</strong> permissions to your role configuration before you apply it. Otherwise, Terraform revokes the access you were granted.</div>
+
 ## Coding agents
 
 The {{< ui >}}Coding Agents{{< /ui >}} tab gives you a top-level view of coding agent activity across your organization. By default, the view aggregates all coding agents and can be filtered to a single agent.
@@ -112,3 +123,4 @@ To start sending data to Agent Console, see [Set Up Agent Console][8].
 [6]: /bits_ai/bits_code/
 [7]: /actions/agents/
 [8]: /ai_agents_console/setup/
+[9]: /account_management/rbac/permissions/


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00db9e0e-96a4-48c6-b0d4-bc91b2c5a5c3","source":"chat","resourceId":"f5e286f6-d552-45ef-a494-d2967b8fa34a","workflowId":"ca89a9d1-f1fc-47c1-9361-061c6d6321e1","codeChangeId":"ca89a9d1-f1fc-47c1-9361-061c6d6321e1","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Agent Console now has its own read and write permissions instead of relying on Agent Observability access, so the Agent Console page needs to tell customers which permission gates viewing versus configuring, how existing roles keep access, and what Terraform-managed custom roles must include to avoid losing that access.

Source PR: https://github.com/ddoghq/dd-source/pull/78822

Changes:

- Add a `## Permissions` section to `hugo/content/en/ai_agents_console/_index.md`, before `## Coding agents`, listing the Agent Console read and write permissions.
- Note that roles with Agent Observability read or write access receive the matching Agent Console permission, and that administrators can remove it independently afterward.
- Add a warning for customers managing custom roles with Terraform to include the Agent Console permissions in their role configuration before applying.
- Add a reference link to the RBAC permissions page.

Testing:

- Reviewed the rendered markdown structure, heading placement, bullet and warning formatting, and reference-link numbering against the rest of the page.
- Confirmed permission naming and the `alert alert-warning` callout style match existing Datadog documentation conventions.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code, then manually reviewed against the page's existing structure and the repository style guide.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f5e286f6-d552-45ef-a494-d2967b8fa34a)

Comment @datadog to request changes