### PR TITLE
Add Remote Configuration destination for US1-FED and US2-FED sites

### DIFF
--- a/hugo/content/en/agent/configuration/network.md
+++ b/hugo/content/en/agent/configuration/network.md
@@ -89,10 +89,16 @@ API test results for the Synthetics Worker > v0.1.6: `intake.synthetics.`{{< reg
 Browser test results for the Synthetics Worker > v0.2.0: `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for the Synthetics Worker < v0.1.5: `api.`{{< region-param key="dd_site" code="true" >}}
 
-{{% site-region region="us,eu,us3,us5,ap1,ap2,uk1" %}}
+{{% site-region region="us,eu,us3,us5,ap1,ap2,uk1,gov,gov2" %}}
 
 [Remote Configuration][101]
 : `config.`{{< region-param key="dd_site" code="true" >}}
+
+[101]: /remote_configuration
+
+{{% /site-region %}}
+
+{{% site-region region="us,eu,us3,us5,ap1,ap2,uk1" %}}
 
 [Database Monitoring][102]
 : `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
@@ -102,7 +108,6 @@ API test results for the Synthetics Worker < v0.1.5: `api.`{{< region-param key=
 : `softinv-intake.`{{< region-param key="dd_site" code="true" >}}<br>
 `eudm-intake.`{{< region-param key="dd_site" code="true" >}}
 
-[101]: /remote_configuration
 [102]: /database_monitoring/
 [103]: /infrastructure/end_user_device_monitoring/
 

--- a/hugo/content/en/agent/configuration/network.md
+++ b/hugo/content/en/agent/configuration/network.md
@@ -89,10 +89,8 @@ API test results for the Synthetics Worker > v0.1.6: `intake.synthetics.`{{< reg
 Browser test results for the Synthetics Worker > v0.2.0: `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for the Synthetics Worker < v0.1.5: `api.`{{< region-param key="dd_site" code="true" >}}
 
-[Remote Configuration][101]
+[Remote Configuration][34]
 : `config.`{{< region-param key="dd_site" code="true" >}}
-
-[101]: /remote_configuration
 
 {{% site-region region="us,eu,us3,us5,ap1,ap2,uk1" %}}
 
@@ -344,3 +342,4 @@ If you are installing the Datadog Operator in a Kubernetes environment with limi
 [31]: /data_security/logs/#hipaa-enabled-customers
 [32]: /logs/log_collection/#logging-endpoints
 [33]: /network_monitoring/network_path/setup/#source-public-ip-resolution
+[34]: /remote_configuration

--- a/hugo/content/en/agent/configuration/network.md
+++ b/hugo/content/en/agent/configuration/network.md
@@ -89,14 +89,10 @@ API test results for the Synthetics Worker > v0.1.6: `intake.synthetics.`{{< reg
 Browser test results for the Synthetics Worker > v0.2.0: `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for the Synthetics Worker < v0.1.5: `api.`{{< region-param key="dd_site" code="true" >}}
 
-{{% site-region region="us,eu,us3,us5,ap1,ap2,uk1,gov,gov2" %}}
-
 [Remote Configuration][101]
 : `config.`{{< region-param key="dd_site" code="true" >}}
 
 [101]: /remote_configuration
-
-{{% /site-region %}}
 
 {{% site-region region="us,eu,us3,us5,ap1,ap2,uk1" %}}
 


### PR DESCRIPTION
## Summary
Adds the Remote Configuration destination (`config.ddog-gov.com` / `config.us2.ddog-gov.com`) to the Agent network traffic destinations page for the US1-FED and US2-FED Datadog sites.

## Motivation
Remote Configuration has been approved for FedRAMP GovCloud use, so it can now be self-service enabled by products for customers on US1-FED and US2-FED. The destinations page was missing the Remote Configuration entry for these two sites, so customers enabling it there had no documented hostname to add to their network allowlists.