### PR TITLE
Update AI Credit limits permission

### DIFF
--- a/hugo/content/en/account_management/billing/ai_credit_limits.md
+++ b/hugo/content/en/account_management/billing/ai_credit_limits.md
@@ -66,4 +66,4 @@ Attribution determines whose limit applies to a given unit of AI usage, and who 
 [3]: /bits_ai/bits_code/
 [4]: /actions/agents/
 [5]: https://app.datadoghq.com/bits-ai/ai-credits-management
-[6]: /account_management/rbac/permissions/
+[6]: /account_management/rbac/permissions/#billing-and-usage

--- a/hugo/content/en/account_management/billing/ai_credit_limits.md
+++ b/hugo/content/en/account_management/billing/ai_credit_limits.md
@@ -13,11 +13,7 @@ Organization admins can set monthly caps on AI Credit usage at the organization 
 
 ## Permissions
 
-To view and set AI Credit limits, a user needs all of the following [permissions][6]:
-
-- `user_access_manage`
-- `billing_edit`
-- `org_management`
+To view and set AI Credit limits, a user needs the [`billing_edit` permission][6].
 
 ## Where to set limits
 


### PR DESCRIPTION
## Summary

- Document that only billing_edit is required to view and set AI Credit limits.
- Remove the outdated user_access_manage and org_management requirements.
- Confirm that the usage-quota API references already require only billing_edit.

## Testing

- git diff --check