### PR TITLE
Add a few sentences to incident app's transition forms documentation

### DIFF
--- a/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
+++ b/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
@@ -9,6 +9,8 @@ Any time an incident progresses through status changes, you can guide responders
 
 {{< img src="/incident_response/incident_management/setup_and_configuration/status_transition_form.png" alt="Status Change form prompting the user to fill out the required Teams and Postmortem Owner fields when moving an incident to Resolved" style="width:70%;" >}}
 
+Required fields on transition forms gate status transitions made via human input. Automated status changes, such as those triggered through API calls or workflow automations, are not impacted. Transition forms are intended to standardize human behavior; automated status changes can already be conditioned based on their own logic.
+
 ## Prerequisites
 
 To set up transition forms, you must have the `Incident Settings Write` permission. For more information, see [Datadog Role Permissions][1].
@@ -19,7 +21,7 @@ To set up transition forms, you must have the `Incident Settings Write` permissi
 1. Under **Incident Types**, expand an incident type to edit.
 1. Click the **Transition Forms** tab.
 1. Select the status you want to configure.
-1. Choose which fields appear on the form. You can add [property fields][3] and [responder types][4]. Any field can be marked as required or optional.
+1. Choose which fields appear on the form. You can add [property fields][3] and [responder types][4]. Any field can be marked as required or optional. 
 1. Click **Save**.
 
 [1]: /account_management/rbac/permissions/#case-and-incident-management

--- a/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
+++ b/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
@@ -21,7 +21,7 @@ To set up transition forms, you must have the `Incident Settings Write` permissi
 1. Under **Incident Types**, expand an incident type to edit.
 1. Click the **Transition Forms** tab.
 1. Select the status you want to configure.
-1. Choose which fields appear on the form. You can add [property fields][3] and [responder types][4]. Any field can be marked as required or optional. 
+1. Choose which fields appear on the form. You can add [property fields][3] and [responder types][4]. Any field can be marked as required or optional.
 1. Click **Save**.
 
 [1]: /account_management/rbac/permissions/#case-and-incident-management

--- a/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
+++ b/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
@@ -9,7 +9,7 @@ Any time an incident progresses through status changes, you can guide responders
 
 {{< img src="/incident_response/incident_management/setup_and_configuration/status_transition_form.png" alt="Status Change form prompting the user to fill out the required Teams and Postmortem Owner fields when moving an incident to Resolved" style="width:70%;" >}}
 
-Required fields on transition forms gate status transitions made with human input. Automated status changes, such as those triggered through API calls or workflow automations, are not impacted. Transition forms are intended to standardize human behavior; automated status changes can already be conditioned based on their own logic.
+<div class="alert alert-info">Required fields on transition forms apply only to status changes made by a human. Automated status changes, such as those triggered through the API or <a href="/incident_response/incident_management/setup_and_configuration/automations">incident automations</a>, are not blocked.</div>
 
 ## Prerequisites
 

--- a/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
+++ b/hugo/content/en/incident_response/incident_management/setup_and_configuration/transition_forms.md
@@ -9,7 +9,7 @@ Any time an incident progresses through status changes, you can guide responders
 
 {{< img src="/incident_response/incident_management/setup_and_configuration/status_transition_form.png" alt="Status Change form prompting the user to fill out the required Teams and Postmortem Owner fields when moving an incident to Resolved" style="width:70%;" >}}
 
-Required fields on transition forms gate status transitions made via human input. Automated status changes, such as those triggered through API calls or workflow automations, are not impacted. Transition forms are intended to standardize human behavior; automated status changes can already be conditioned based on their own logic.
+Required fields on transition forms gate status transitions made with human input. Automated status changes, such as those triggered through API calls or workflow automations, are not impacted. Transition forms are intended to standardize human behavior; automated status changes can already be conditioned based on their own logic.
 
 ## Prerequisites
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
Incident app would like to add a few sentences to the transition forms documentation that explains how this feature is intended to be used. 

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
