### PR TITLE
[DSM2-313] Rename Data Streams left nav entry to Kafka Console

### DIFF
--- a/hugo/config/_default/menus/main.en.yaml
+++ b/hugo/config/_default/menus/main.en.yaml
@@ -5326,7 +5326,7 @@ menu:
       identifier: data_streams_setup
       parent: data_streams
       weight: 1
-    - name: Kafka
+    - name: Kafka Console
       url: data_streams/kafka
       identifier: data_streams_kafka
       parent: data_streams


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DSM2-313

Renames the Data Streams Monitoring left navigation entry from "Kafka" to "Kafka Console", matching the page title and the product name.

Only the English menu is updated; the localized menus are managed through the translation pipeline.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code located the menu entry and made the one-line edit.

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
