### PR TITLE
[CCC-2474] Warn against manually migrating Legacy CUR to CUR 2.0

### DIFF
--- a/hugo/content/en/cloud_cost_management/setup/aws.md
+++ b/hugo/content/en/cloud_cost_management/setup/aws.md
@@ -275,6 +275,8 @@ The **Set up with AI Agent** flow creates or imports a Cost and Usage Report and
 
 {{< /tabs >}}
 
+<div class="alert alert-warning">Deleting a Legacy CUR account and configuring a new CUR 2.0 account can result in duplicate charges. Enable CUR 2.0 only when you configure a new AWS account.</div>
+
 #### Permissions for AWS Cost Optimization Hub recommendations
 
 Cloud Cost Management generates some [recommendations][30] from data sourced from [AWS Cost Optimization Hub][31]. For Datadog to receive these recommendations, the Datadog AWS integration IAM role must include the following permissions:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a warning to the CCM AWS setup public docs saying that customers may get double charged if they try to manually migrate from CUR 1.0 to CUR 2.0.

Jira: [CCC-2474](https://datadoghq.atlassian.net/browse/CCC-2474)

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the page and draft the callout; wording reviewed and revised by the author.

### Additional notes



[CCC-2474]: https://datadoghq.atlassian.net/browse/CCC-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ