### PR TITLE
Add sensitivity slider to Data Observability monitor docs

### DIFF
--- a/hugo/content/en/monitors/types/data_observability.md
+++ b/hugo/content/en/monitors/types/data_observability.md
@@ -222,6 +222,7 @@ For monitors using the {{< ui >}}Anomalies{{< /ui >}} detection method, expand {
 | {{< ui >}}Alert after N consecutive anomalies{{< /ui >}} | The number of consecutive failed evaluations before the monitor alerts. Configure this setting to suppress isolated spikes. |
 | {{< ui >}}Minimum upper bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the upper end. |
 | {{< ui >}}Minimum lower bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the lower end. |
+| {{< ui >}}Sensitivity{{< /ui >}} | Controls the width of the expected bounds. Move the slider toward {{< ui >}}Fewer alerts{{< /ui >}} (left) for wider bounds, or toward {{< ui >}}More alerts{{< /ui >}} (right) for narrower bounds. Configured minimum bound sizes still apply. |
 
 ### Monitor schedule
 

--- a/hugo/content/en/monitors/types/data_observability.md
+++ b/hugo/content/en/monitors/types/data_observability.md
@@ -220,9 +220,9 @@ For monitors using the {{< ui >}}Anomalies{{< /ui >}} detection method, expand {
 | Setting | Description |
 |---|---|
 | {{< ui >}}Alert after N consecutive anomalies{{< /ui >}} | The number of consecutive failed evaluations before the monitor alerts. Configure this setting to suppress isolated spikes. |
-| {{< ui >}}Minimum upper bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the upper end. |
-| {{< ui >}}Minimum lower bound size{{< /ui >}} | Constrains how tightly the model tracks your data on the lower end. |
-| {{< ui >}}Sensitivity{{< /ui >}} | Controls the width of the expected bounds. Move the slider toward {{< ui >}}Fewer alerts{{< /ui >}} (left) for wider bounds, or toward {{< ui >}}More alerts{{< /ui >}} (right) for narrower bounds. Configured minimum bound sizes still apply. |
+| {{< ui >}}Minimum upper bound size{{< /ui >}} | Expand bounds to a minimum amount above the predicted value. |
+| {{< ui >}}Minimum lower bound size{{< /ui >}} | Expand bounds to a minimum amount below the predicted value. |
+| {{< ui >}}Sensitivity{{< /ui >}} | Controls bound width. Move the slider toward {{< ui >}}Fewer alerts{{< /ui >}} (left) for wider bounds, or toward {{< ui >}}More alerts{{< /ui >}} (right) for narrower bounds. Configured minimum bound sizes still apply. |
 
 ### Monitor schedule
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Data Observability monitor documentation does not describe the Sensitivity slider. Add it to the Model configuration settings table, explaining the Fewer alerts and More alerts directions and how minimum bound sizes interact with sensitivity.

Follows #39705 and preserves the existing Preview callout.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

AI assisted with drafting and checking the documentation against the product controls.

### Additional notes

English documentation only. Validation results are added after the PR preview is checked.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
