### PR TITLE
Document versioned prompt configuration

### DIFF
--- a/hugo/content/en/llm_observability/configure/prompt_management.md
+++ b/hugo/content/en/llm_observability/configure/prompt_management.md
@@ -287,6 +287,125 @@ Use `LLMObs.list_prompts()` and `LLMObs.list_prompt_versions()` to inspect manag
 
 Use the Prompt Management API to create, retrieve, update, and delete prompts and prompt versions. See the [Agent Observability API reference][8] for endpoint schemas, request media types, and examples.
 
+## Version prompt configuration
+
+A prompt version contains its template and an optional customer-owned JSON configuration object. Keeping both values on
+the same immutable version prevents an environment from mixing settings from one version with a template from another.
+An environment selects, promotes, or rolls back the complete behavior bundle.
+
+Use configuration for application settings such as a model name, temperature, tool definition, or structured-output
+schema. The value must be a top-level JSON object. Nested objects, arrays, numbers, strings, Booleans, and `null` values
+are supported, and unknown keys are preserved.
+
+Datadog stores and returns the declared configuration without interpolating it, validating provider-specific keys, or
+applying it to a model call. Your application chooses which values to apply. The effective configuration is the set of
+arguments that the application passes to the model provider, which can differ from the declared configuration. Do not
+store credentials, tokens, private keys, or other secrets in a prompt configuration.
+
+### Language support
+
+Versioned prompt configuration is available through the Prompt Management API. Released SDK support is:
+
+| SDK | Versioned prompt configuration |
+|-----|--------------------------------|
+| Python (`ddtrace`) | Not available in a released version |
+| Go (`dd-trace-go`) | Not available |
+| JavaScript (`dd-trace-js`) | Not available |
+
+Use the API for configuration reads and writes. Continue to use the SDK support described elsewhere on this page for
+prompt templates and Prompt Tracking.
+
+### Create a configured prompt
+
+In the {{< ui >}}Prompt Editor{{< /ui >}}, enter a JSON object in the {{< ui >}}Configuration{{< /ui >}} editor before
+saving the prompt. The following create-prompt request stores the template and configuration on version 1:
+
+```json
+{
+  "data": {
+    "type": "prompt-templates",
+    "attributes": {
+      "prompt_id": "document-extractor",
+      "template": [
+        {
+          "role": "system",
+          "content": "Extract fields from {{document}}."
+        }
+      ],
+      "config": {
+        "model": "provider-model",
+        "temperature": 0,
+        "response_format": {
+          "type": "json_object"
+        }
+      }
+    }
+  }
+}
+```
+
+If `config` is omitted when version 1 is created, Datadog stores `{}`.
+
+### Retrieve and apply configuration
+
+Retrieve an exact version with `GET /api/v2/llm-obs/v1/prompts/document-extractor/versions/1`. The response returns the
+template and configuration in the same `data.attributes` object. Apply only the settings that your application supports:
+
+```python
+attributes = prompt_version_response["data"]["attributes"]
+messages = format_prompt(attributes["template"], document=document)
+declared_config = attributes["config"]
+
+response = model_client.generate(
+    messages=messages,
+    model=declared_config["model"],
+    temperature=declared_config["temperature"],
+    response_format=declared_config["response_format"],
+)
+```
+
+This example applies every declared field, but applications can validate, transform, or ignore fields before calling the
+provider. Datadog does not copy declared prompt configuration into the configuration recorded from a model call.
+
+### Create a configuration-only version
+
+To change configuration without changing prompt text, create an ordinary version and send the same required template
+with the changed configuration. For example, the following request creates version 2 with a different temperature:
+
+```json
+{
+  "data": {
+    "type": "prompt-template-versions",
+    "attributes": {
+      "template": [
+        {
+          "role": "system",
+          "content": "Extract fields from {{document}}."
+        }
+      ],
+      "config": {
+        "model": "provider-model",
+        "temperature": 0.4,
+        "response_format": {
+          "type": "json_object"
+        }
+      }
+    }
+  }
+}
+```
+
+When creating a later version, omitting `config` carries forward the latest version's configuration. Sending
+`"config": {}` explicitly clears it. The `config` field cannot be changed with the prompt-version metadata update
+operation because configuration is immutable after version creation.
+
+### Promote and roll back a configuration
+
+Deploy version 2 to a staging environment and retrieve it from an application configured for that environment. The
+selected bundle contains version 2's template and configuration. To promote the tested bundle, deploy version 2 to the
+production environment. To roll back, deploy version 1 to production again. Environment selection always moves the
+template and configuration together.
+
 ## Advanced usage
 
 ### Serve multiple versions from one environment


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Document how to save application settings with a prompt template and deploy or roll back both as one version.

The guide follows the customer workflow:
- Create a prompt and add configuration in the save dialog.
- View, copy, update, review, and compare configuration in the UI.
- Create prompts and versions through the API, with explicit endpoints and JSON:API request examples.
- Retrieve settings and apply application defaults when configuration is absent or incomplete.
- Deploy and roll back the template and configuration together.

Availability and disabled-authoring behavior are documented separately from the main workflow. Released SDKs are not presented as supporting configuration.

### Validation

- All three JSON examples parse.
- The Python example passes checks for absent, empty, complete, and partial configuration.
- Vale 3.9.1 with Datadog rules reports no findings in the revised section; existing findings elsewhere on the page are unchanged.
- Git whitespace checks pass. A full Hugo render was not run locally.

### Configuration rollout

Configuration authoring must be enabled for the organization to explicitly send `config` in create-prompt or create-version requests. When disabled, explicit `config`, including `{}`, returns HTTP `403`. Omission still stores `{}` for a new prompt or inherits the latest configuration for a new version. When configuration authoring is disabled, customer API responses omit empty `config`; non-empty saved configuration remains returned. When enabled, complete responses include `config`, including `{}`. The response field is optional in schemas and client types; missing config defaults to `{}` in the SDKs.

<!-- prompt-config-initiative-context:start -->
## API surface

**No endpoint, request, or response shape changes.** This documentation-only PR explains the additive `config` field delivered by [BCFG](https://github.com/ddoghq/dd-source/pull/86374) and [APICFG](https://github.com/DataDog/datadog-api-spec/pull/6669), including SDK retrieval, authoring, inheritance, and explicit clearing.

## Initiative stack

| Stream | Pull request | Scope |
|---|---|---|
| KCFG-S | [pull#4085](https://github.com/ddoghq/k8s-resources/pull/4085) | Staging OrgStore column and object constraint — merged/deployed |
| BCFG | [pull#86374](https://github.com/ddoghq/dd-source/pull/86374) | Backend storage, management responses, SDK retrieval, and opaque FFE delivery |
| MP1-PY | [pull#20210](https://github.com/DataDog/dd-trace-py/pull/20210) | Python SDK retrieval, caches, fallback, and authoring |
| UICFG | [pull#11271](https://github.com/ddoghq/web-ui/pull/11271) | Prompt authoring, detail, and comparison UI |
| STCFG | [pull#7684](https://github.com/DataDog/system-tests/pull/7684) | Dropped — cassette replay duplicated SDK/backend coverage and did not exercise live FFE |
| KCFG-P | [pull#4124](https://github.com/ddoghq/k8s-resources/pull/4124) | Production OrgStore migration |
| MP1-GO | [pull#5333](https://github.com/DataDog/dd-trace-go/pull/5333) | Go SDK retrieval add-on; stacked on foundation [#5298](https://github.com/DataDog/dd-trace-go/pull/5298) |
| MP1-JS | [pull#10268](https://github.com/DataDog/dd-trace-js/pull/10268) | Node.js SDK retrieval/authoring add-on; stacked on foundation [#10015](https://github.com/DataDog/dd-trace-js/pull/10015) |
| APICFG | [pull#6669](https://github.com/DataDog/datadog-api-spec/pull/6669) | Public OpenAPI request/response contract |
| **DOCSCFG (this PR)** | **[DataDog/documentation#39823](https://github.com/DataDog/documentation/pull/39823)** | Customer documentation |

Go and Node.js are non-blocking add-ons; their foundation merges and later retargeting do not block the core initiative.
<!-- prompt-config-initiative-context:end -->

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ The branch follows the required name/description convention.

### AI assistance

Used Codex to draft the scoped section and validate it against the implementation and public API contract.

### Additional notes

The draft intentionally excludes automatic Playground behavior and unreleased SDK support.
