### PR TITLE
Remove preview messaging from Sheets documentation

### DIFF
--- a/hugo/content/en/sheets/_index.md
+++ b/hugo/content/en/sheets/_index.md
@@ -24,7 +24,7 @@ Sheets lets you manipulate, transform, and analyze data from logs, real user mon
 
 - [{{< ui >}}Table{{< /ui >}}](#table): Query live data from a Datadog data source and enrich it with calculated columns, lookups, and filters.
 - [{{< ui >}}Pivot{{< /ui >}}](#pivot): Summarize and aggregate data from a table with custom dimensions and calculations.
-- [{{< ui >}}Sheet{{< /ui >}}](#sheet-preview) (Preview): A flexible, blank-canvas spreadsheet where you can write formulas referencing data directly from a table to build models, reports, or track operations.
+- [{{< ui >}}Sheet{{< /ui >}}](#sheet): A flexible, blank-canvas spreadsheet where you can write formulas referencing data directly from a table to build models, reports, or track operations.
 
 ## Table
 
@@ -77,11 +77,7 @@ After you add a table of data to a spreadsheet, analyze and add context to your 
 
 After you have your pivot table, you can click {{< ui >}}Show Graphs{{< /ui >}} and add up to six widgets to graph your data. Supported widget types include {{< ui >}}Top List{{< /ui >}}, {{< ui >}}Treemap{{< /ui >}}, and {{< ui >}}Pie Chart{{< /ui >}} widgets. Hover over the widget title to delete, duplicate, expand, export, and reposition widgets. To edit a widget, click the pencil icon. Editing options allow you to select the widget type, choose which pivot calculation to graph (if there is more than one), and specify the rows, columns, and the number of groupings graphed per row or column.
 
-## Sheet (Preview)
-
-{{< callout url="https://www.datadoghq.com/product-preview/flexible-spreadsheets-in-datadog-sheets/">}}
-Create flexible spreadsheets: built to let you start from scratch, build models, track operations, and more.
-{{< /callout >}}
+## Sheet
 
 A sheet is a flexible, blank-canvas spreadsheet with a full formula engine. Use it to build financial models, operational trackers, planning templates, or any freeform calculation that doesn't fit a query-based workflow.
 

--- a/hugo/content/en/sheets/functions_operators.md
+++ b/hugo/content/en/sheets/functions_operators.md
@@ -339,4 +339,4 @@ Use functions and operators in Sheets to analyze and transform your data. Functi
 `TYPE(value)`
 : Returns the data type of a value as a number (1 = number, 2 = text, 4 = logical, 16 = error). <br>**Example**: `TYPE(123) => 1` <br>**Available in**: Sheet
 
-[1]: /sheets/#sheet-preview
+[1]: /sheets/#sheet


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Remove outdated preview messaging from the Sheets documentation.

## Changes

- Remove the flexible-spreadsheet preview signup callout and Preview labels.
- Update the overview and Functions and Operators links to the Sheet heading.
- Keep the separate additional-data-sources request form unchanged.

## QA Instructions

In the generated documentation preview:
1. Open `/sheets/` and confirm the Sheet heading has no Preview label or signup callout.
2. Follow the Sheet link in the overview and the Sheet reference in `/sheets/functions_operators/`; both should target `/sheets/#sheet`.
3. Confirm the additional-data-sources request form remains.

Local checks: `git diff --check` and repository pre-commit checks passed. Vale and Hugo were not available locally; style linting and the site build were not run.

## Blast Radius

English Sheets documentation only. No application code or translated content changed. The section anchor changes from `#sheet-preview` to `#sheet`; links in the English Sheets pages are updated.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- Branch follows the required `<name>/<description>` convention.

### AI assistance

Used Pi to make the documentation edits, check the diff and links, and prepare this PR.

### Additional notes

Documentation preview pending the PR build.