### PR TITLE
Add message placeholders to Prompt Management

### DIFF
--- a/hugo/content/en/llm_observability/configure/prompt_management.md
+++ b/hugo/content/en/llm_observability/configure/prompt_management.md
@@ -128,7 +128,7 @@ Managed prompts cannot reference other managed prompts in their templates. To co
 
 ### Insert runtime messages with a message placeholder
 
-Use a message placeholder when a managed chat prompt must include per-request conversation history or another runtime text-message list. In the initial release, every inserted message must have string `role` and `content` fields. Add the placeholder as a complete item in the existing chat-template array:
+Use a message placeholder when a managed chat prompt must include per-request conversation history or another runtime message list. Every inserted message must have a string `role` and either string `content` or a non-empty `tool_calls` or `tool_results` list. `content` can be `null` or omitted when tool content is present. Add the placeholder as a complete item in the existing chat-template array:
 
 ```json
 [
@@ -215,9 +215,9 @@ const messages = prompt.format(variables)
 {{% /tab %}}
 {{< /tabs >}}
 
-An empty list inserts no messages. A missing value, a non-list value, an item without string `role` and `content` fields, or structured content causes formatting to fail before the model call. Repeated placeholders reuse the same supplied list, and multiple placeholder names are supported.
+An empty list inserts no messages. A missing value, a non-list value, or an item without a string `role` and text or tool content causes formatting to fail before the model call. Repeated placeholders reuse the same supplied list, and multiple placeholder names are supported.
 
-Inserted text messages are copied without interpolation. Additional JSON-compatible fields are retained without interpretation; the model provider remains responsible for validating them. Multimodal content and tool-only messages are not supported in the initial release. The generic `type: "placeholder"` directive leaves room to broaden accepted message values later without changing stored prompt templates; this does not guarantee future support for any provider-specific shape.
+Inserted messages are copied without interpolation. Tool calls, tool results, and additional JSON-compatible fields are retained without interpretation; the model provider remains responsible for validating their inner shape. Multimodal image, audio, and content-block values are not supported yet. The generic `type: "placeholder"` directive leaves room to add them later without changing stored prompt templates; this does not guarantee future support for any provider-specific shape.
 
 The tracked prompt contains the authored placeholder declaration, not the expanded runtime messages. Message-placeholder values are excluded from `prompt.variables`. Expanded messages are captured only as normal span input and therefore follow the existing Agent Observability input-capture and privacy settings. When automatic prompt association is unavailable, annotate the containing prompt explicitly:
 
@@ -411,7 +411,7 @@ Use the Prompt Management API to create, retrieve, update, and delete prompts an
 
 ### Test message placeholders in the Playground
 
-For each distinct placeholder name, the Playground displays one temporary test-value input. Repeated placeholders share that input. Enter a JSON array of text messages to see the final flat message list before running the prompt; enter `[]` to insert no messages. Invalid input shows an error and prevents the model call.
+For each distinct placeholder name, the Playground displays one temporary test-value input. Repeated placeholders share that input. Enter a JSON array of text or tool messages to see the final flat message list before running the prompt; enter `[]` to insert no messages. Invalid input shows an error and prevents the model call.
 
 Playground test values are not saved with the prompt or recorded as prompt variables. If you run the prompt, the rendered messages become model input and follow your existing Agent Observability input-capture and privacy settings.
 

--- a/hugo/content/en/llm_observability/configure/prompt_management.md
+++ b/hugo/content/en/llm_observability/configure/prompt_management.md
@@ -128,7 +128,7 @@ Managed prompts cannot reference other managed prompts in their templates. To co
 
 ### Insert runtime messages with a message placeholder
 
-Use a message placeholder when a managed chat prompt must include per-request conversation history or another runtime message list. Add the placeholder as a complete item in the existing chat-template array:
+Use a message placeholder when a managed chat prompt must include per-request conversation history or another runtime text-message list. In the initial release, every inserted message must have string `role` and `content` fields. Add the placeholder as a complete item in the existing chat-template array:
 
 ```json
 [
@@ -215,9 +215,9 @@ const messages = prompt.format(variables)
 {{% /tab %}}
 {{< /tabs >}}
 
-An empty list inserts no messages. A missing value, a non-list value, or an item without string `role` and `content` fields causes formatting to fail before the model call. Repeated placeholders reuse the same supplied list, and multiple placeholder names are supported.
+An empty list inserts no messages. A missing value, a non-list value, an item without string `role` and `content` fields, or structured content causes formatting to fail before the model call. Repeated placeholders reuse the same supplied list, and multiple placeholder names are supported.
 
-Inserted messages are copied without interpolation. Additional JSON-compatible fields, such as a provider-specific tool-call identifier, are retained without interpretation; the model provider remains responsible for validating them.
+Inserted text messages are copied without interpolation. Additional JSON-compatible fields are retained without interpretation; the model provider remains responsible for validating them. Multimodal content and tool-only messages are not supported in the initial release. The generic `type: "placeholder"` directive leaves room to broaden accepted message values later without changing stored prompt templates; this does not guarantee future support for any provider-specific shape.
 
 The tracked prompt contains the authored placeholder declaration, not the expanded runtime messages. Message-placeholder values are excluded from `prompt.variables`. Expanded messages are captured only as normal span input and therefore follow the existing Agent Observability input-capture and privacy settings. When automatic prompt association is unavailable, annotate the containing prompt explicitly:
 
@@ -411,11 +411,13 @@ Use the Prompt Management API to create, retrieve, update, and delete prompts an
 
 ### Test message placeholders in the Playground
 
-For each distinct placeholder name, the Playground displays one message-list input. Repeated placeholders share that input. Enter a JSON array of messages to see the final flat message list before running the prompt; enter `[]` to omit that placeholder. Invalid input shows an error and prevents the model call.
+For each distinct placeholder name, the Playground displays one temporary test-value input. Repeated placeholders share that input. Enter a JSON array of text messages to see the final flat message list before running the prompt; enter `[]` to insert no messages. Invalid input shows an error and prevents the model call.
+
+Playground test values are not saved with the prompt or recorded as prompt variables. If you run the prompt, the rendered messages become model input and follow your existing Agent Observability input-capture and privacy settings.
 
 ### Use message placeholders in experiments
 
-In a prompt experiment, map a dataset input key to a message placeholder with the same name. For example, the `history` field below fills a placeholder named `history`:
+In a prompt experiment, each placeholder resolves automatically from the identically named key in the dataset record's input section. For example, a placeholder named `history` resolves from `input.history`; create records whose `input_data` contains:
 
 ```json
 {
@@ -428,7 +430,7 @@ In a prompt experiment, map a dataset input key to a message placeholder with th
 }
 ```
 
-The experiment preview shows the expanded flat messages before launch. An empty list inserts nothing. A malformed message list fails only that dataset row and does not call the model for that row.
+No separate mapping is required. The experiment preview shows the expanded flat messages before launch. An empty `input.history` list inserts nothing. A missing or malformed `input.history` fails only that dataset row and does not call the model for that row.
 
 ## Advanced usage
 

--- a/hugo/content/en/llm_observability/configure/prompt_management.md
+++ b/hugo/content/en/llm_observability/configure/prompt_management.md
@@ -2,7 +2,7 @@
 title: Prompt Management
 aliases:
 - /llm_observability/monitoring/prompt_management/
-description: Create, version, and retrieve managed prompts in Python applications with Prompt Management.
+description: Create, version, and retrieve managed prompts in Python, Go, and JavaScript applications with Prompt Management.
 
 further_reading:
   - link: "/llm_observability/instrument/prompt_tracking"
@@ -21,7 +21,7 @@ further_reading:
 
 Prompt Management provides a centralized registry for the prompts used by your LLM applications. Instead of hardcoding prompt templates in application code or configuration files, create, version, and update prompts through Agent Observability, then retrieve them at runtime.
 
-Runtime retrieval is supported in Python through the `ddtrace` SDK. Prompt retrieval and Prompt Tracking are separate: `LLMObs.get_prompt()` can retrieve a managed prompt without enabling Agent Observability, but Agent Observability must be enabled to create LLM spans and associate prompt metadata with them.
+Runtime retrieval is supported through the Python, Go, and JavaScript tracing SDKs. Prompt retrieval and Prompt Tracking are separate: an application can retrieve a managed prompt without enabling Agent Observability, but Agent Observability must be enabled to create LLM spans and associate prompt metadata with them.
 
 Prompt Management works alongside [Prompt Tracking][1]. When Agent Observability is enabled, managed prompts passed directly to supported, automatically instrumented LLM calls are associated with the resulting spans.
 
@@ -126,6 +126,127 @@ If retrieval fails and no fallback is provided, `get_prompt()` raises a `ValueEr
 
 Managed prompts cannot reference other managed prompts in their templates. To compose prompts, combine them in application code or manage the final provider-facing prompt as a single prompt.
 
+### Insert runtime messages with a message placeholder
+
+Use a message placeholder when a managed chat prompt must include per-request conversation history or another runtime message list. Add the placeholder as a complete item in the existing chat-template array:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are a concise assistant for {{plan}} customers."
+  },
+  {
+    "type": "placeholder",
+    "name": "history"
+  },
+  {
+    "role": "user",
+    "content": "{{question}}"
+  }
+]
+```
+
+The placeholder name uses the same naming rules as template variables. A prompt version cannot use the same name for both a text variable and a message placeholder.
+
+Placeholder-bearing prompts require these SDK versions. The minimum versions are assigned during release; do not deploy such a prompt to an older SDK:
+
+| Language | Minimum compatible version |
+|---|---|
+| Python | `ddtrace >= <PYTHON_MESSAGE_PLACEHOLDERS_MIN_VERSION>` |
+| Go | `github.com/DataDog/dd-trace-go/v2 >= <GO_MESSAGE_PLACEHOLDERS_MIN_VERSION>` |
+| JavaScript | `dd-trace >= <JAVASCRIPT_MESSAGE_PLACEHOLDERS_MIN_VERSION>` |
+
+Supply the runtime list through the formatter's existing variable namespace. The SDK inserts the messages at the placeholder's exact position.
+
+{{< tabs >}}
+{{% tab "Python" %}}
+```python
+prompt = LLMObs.get_prompt("support-assistant")
+
+messages = prompt.format(
+    plan="enterprise",
+    question="Can I export the report?",
+    history=[
+        {"role": "user", "content": "Where are reports located?"},
+        {"role": "assistant", "content": "Under Analytics."},
+    ],
+)
+```
+{{% /tab %}}
+
+{{% tab "Go" %}}
+```go
+prompt, err := llmobs.GetPrompt(ctx, "support-assistant")
+if err != nil {
+	return err
+}
+
+variables := map[string]any{
+	"plan":     "enterprise",
+	"question": "Can I export the report?",
+	"history": []llmobs.PromptMessage{
+		{Role: "user", Content: "Where are reports located?"},
+		{Role: "assistant", Content: "Under Analytics."},
+	},
+}
+rendered, err := prompt.Format(variables)
+if err != nil {
+	return err
+}
+messages := rendered.Messages
+```
+{{% /tab %}}
+
+{{% tab "JavaScript" %}}
+```javascript
+const prompt = await tracer.llmobs.getPrompt('support-assistant')
+
+const variables = {
+  plan: 'enterprise',
+  question: 'Can I export the report?',
+  history: [
+    { role: 'user', content: 'Where are reports located?' },
+    { role: 'assistant', content: 'Under Analytics.' }
+  ]
+}
+const messages = prompt.format(variables)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+An empty list inserts no messages. A missing value, a non-list value, or an item without string `role` and `content` fields causes formatting to fail before the model call. Repeated placeholders reuse the same supplied list, and multiple placeholder names are supported.
+
+Inserted messages are copied without interpolation. Additional JSON-compatible fields, such as a provider-specific tool-call identifier, are retained without interpretation; the model provider remains responsible for validating them.
+
+The tracked prompt contains the authored placeholder declaration, not the expanded runtime messages. Message-placeholder values are excluded from `prompt.variables`. Expanded messages are captured only as normal span input and therefore follow the existing Agent Observability input-capture and privacy settings. When automatic prompt association is unavailable, annotate the containing prompt explicitly:
+
+{{< tabs >}}
+{{% tab "Python" %}}
+```python
+with LLMObs.annotation_context(prompt=prompt.to_annotation_dict(**variables)):
+    response = client.chat.completions.create(model="gpt-4o", messages=messages)
+```
+{{% /tab %}}
+
+{{% tab "Go" %}}
+```go
+span, _ := llmobs.StartLLMSpan(ctx, "support-request")
+defer span.Finish()
+span.Annotate(llmobs.WithAnnotatedPrompt(prompt.Annotation(variables)))
+```
+{{% /tab %}}
+
+{{% tab "JavaScript" %}}
+```javascript
+const response = tracer.llmobs.annotationContext(
+  { prompt: prompt.toAnnotation(variables) },
+  () => client.chat.completions.create({ model: 'gpt-4o', messages })
+)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Select a version
 
 Without `DD_ENV`, `get_prompt()` retrieves the latest prompt version:
@@ -221,8 +342,9 @@ In the Prompt Editor:
 
 1. Add one or more messages and assign each a role: {{< ui >}}System{{< /ui >}}, {{< ui >}}User{{< /ui >}}, or {{< ui >}}Assistant{{< /ui >}}.
 2. Use `{{variable_name}}` syntax in any message to add dynamic content.
-3. Optional: Click {{< ui >}}Run{{< /ui >}} to test the prompt with sample values.
-4. Click {{< ui >}}Save Prompt{{< /ui >}} to open the save dialog.
+3. Optional: Select {{< ui >}}Add message placeholder{{< /ui >}}, enter a name, and position the placeholder between messages. The editor shows the compatible SDK requirement before you save.
+4. Optional: Click {{< ui >}}Run{{< /ui >}} to test the prompt with sample values.
+5. Click {{< ui >}}Save Prompt{{< /ui >}} to open the save dialog.
 
 Structure the prompt so the user query and context are injected as variables:
 
@@ -286,6 +408,27 @@ Use `LLMObs.list_prompts()` and `LLMObs.list_prompt_versions()` to inspect manag
 ### Use the API
 
 Use the Prompt Management API to create, retrieve, update, and delete prompts and prompt versions. See the [Agent Observability API reference][8] for endpoint schemas, request media types, and examples.
+
+### Test message placeholders in the Playground
+
+For each distinct placeholder name, the Playground displays one message-list input. Repeated placeholders share that input. Enter a JSON array of messages to see the final flat message list before running the prompt; enter `[]` to omit that placeholder. Invalid input shows an error and prevents the model call.
+
+### Use message placeholders in experiments
+
+In a prompt experiment, map a dataset input key to a message placeholder with the same name. For example, the `history` field below fills a placeholder named `history`:
+
+```json
+{
+  "plan": "enterprise",
+  "question": "Can I export the report?",
+  "history": [
+    {"role": "user", "content": "Where are reports located?"},
+    {"role": "assistant", "content": "Under Analytics."}
+  ]
+}
+```
+
+The experiment preview shows the expanded flat messages before launch. An empty list inserts nothing. A malformed message list fails only that dataset row and does not call the model for that row.
 
 ## Advanced usage
 


### PR DESCRIPTION
## Purpose

Document how to insert conversation history and tool interactions into managed prompts without hardcoding their position in application code.

## Changes

- Explain message placeholders in terms of text variables, versioned placement, and comparing prompt versions in experiments.
- Provide a consistent template, runtime inputs, and exact rendered output, with Python, Go, and JavaScript examples.
- Add an OpenAI-style tool-call/response example and clarify that formatting does not execute tools.
- Add actionable Playground and dataset instructions, including first-row preview validation versus row-level execution failures.
- Separate placeholder guidance from Python-specific setup, and keep unsupported values and troubleshooting concise.
- Preserve the organization-availability and input-capture/privacy guidance.

## Merge readiness

- [ ] Ready for merge
- [ ] Confirm and document the minimum released SDK version for each published language example. No versions have been guessed; release-owner placeholders were removed from customer-facing content.
- [ ] If Go or JavaScript support is not released with the initial launch, defer that language's examples and support claim rather than blocking the Python launch.
- [ ] Add a publication-safe screenshot of the placeholder editor and rendered messages, with meaningful sample data and no account information or environment URLs.
- [ ] Review the generated documentation preview and Vale results in CI.

## Checks

- All 10 Python code blocks parse; all four JSON examples parse.
- The Python formatter implementation produces the exact documented four-message output. The tool-message example passes its message validation, and dataset inputs match the runtime example.
- Git whitespace checks pass.
- Local Vale and Hugo verification unavailable: executables are not installed. No full-site render or Go/JavaScript execution is claimed.

## API / contract changes

None in this PR; documentation only. The authored placeholder remains `{"type":"placeholder","name":"history"}`.

## AI assistance

AI assisted with restructuring the guide, checking examples against the implementation, and reviewing wording. Publication prerequisites remain explicit above.

## Initiative stack

**This PR:** customer documentation.

Merge required phases in order. PRs in the same phase may merge in parallel after their prerequisites. Rows marked **2+** are optional plus deliverables and do not block later phases.

| Phase | Slice | Pull request | Prerequisite |
|---:|---|---|---|
| 0 | Go managed-prompt baseline | [DataDog/dd-trace-go#5298](https://github.com/DataDog/dd-trace-go/pull/5298) | Required only by Go SDK #5334 |
| 0 | JavaScript managed-prompt baseline | [DataDog/dd-trace-js#10015](https://github.com/DataDog/dd-trace-js/pull/10015) | Required only by JavaScript SDK #10269 |
| 1 | Backend acceptance and serving | [ddoghq/dd-source#86350](https://github.com/ddoghq/dd-source/pull/86350) | — |
| 2 | API schema | [DataDog/datadog-api-spec#6674](https://github.com/DataDog/datadog-api-spec/pull/6674) | #86350 |
| 2 | Python SDK | [DataDog/dd-trace-py#20206](https://github.com/DataDog/dd-trace-py/pull/20206) | #86350 |
| **2+** | Go SDK | [DataDog/dd-trace-go#5334](https://github.com/DataDog/dd-trace-go/pull/5334) | #86350 and #5298 |
| **2+** | JavaScript SDK | [DataDog/dd-trace-js#10269](https://github.com/DataDog/dd-trace-js/pull/10269) | #86350 and #10015 |
| 3 | Prompt authoring UI | [ddoghq/web-ui#11327](https://github.com/ddoghq/web-ui/pull/11327) | #86350 and a compatible SDK release |
| 4 | Playground UI | [ddoghq/web-ui#11351](https://github.com/ddoghq/web-ui/pull/11351) | #11327 |
| 4 | Experiment execution | [ddoghq/dd-source#86731](https://github.com/ddoghq/dd-source/pull/86731) | #86350 |
| 5 | Experiment UI | [ddoghq/web-ui#11392](https://github.com/ddoghq/web-ui/pull/11392) | #11351 and #86731 |
| 6 | Customer documentation | [DataDog/documentation#39830](https://github.com/DataDog/documentation/pull/39830) | SDK release versions assigned |
