### PR TITLE
Add test line to Code Security page

### DIFF
--- a/hugo/content/en/security/code_security/_index.md
+++ b/hugo/content/en/security/code_security/_index.md
@@ -36,6 +36,8 @@ aliases:
 - /code_analysis/
 ---
 
+test
+
 Code Security scans your first-party code and open source libraries used in your applications in both your repositories and running services, providing end-to-end visibility from development to production. It encompasses the following capabilities:
 
 - [Static Code Analysis (SAST)][1] for identifying security and quality issues in your first-party code


### PR DESCRIPTION
<!-- dd-meta {"pullId":"22d07ee9-dff4-42a2-90a7-410f89a250a5","source":"chat","resourceId":"d9f207f8-5968-47e2-98f6-b48e2245d1c1","workflowId":"14fcb25c-974e-4030-bb88-9d7e449ed67d","codeChangeId":"14fcb25c-974e-4030-bb88-9d7e449ed67d","sourceType":"chat"} -->
### What does this PR do? What is the motivation?

The Code Security documentation page needs a test line directly beneath its title.

Changes:
- Adds `test` as the first rendered line on hugo/content/en/security/code_security/_index.md.

### Testing

- Ran `git diff --check`.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code to make and validate the requested documentation edit.

### Additional notes

None.

---

PR by Bits - [View session in Datadog](https://ddstaging.datadoghq.com/code/d9f207f8-5968-47e2-98f6-b48e2245d1c1)

Comment @datadog to request changes