### PR TITLE
Document llmobs MCP feedback labels tool

### DIFF
--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -358,7 +358,7 @@ The `llmobs` toolset includes the following tools:
 : List all LLM-judge evaluators configured for a specific ML application.
 
 `list_llmobs_feedback_labels`
-: List all the feedback labels that end users submitted for a specific ML application.
+: List all feedback labels submitted by end users for a specific ML application.
 
 `get_llmobs_evaluator`
 : Retrieve an LLM-judge evaluator configuration by name, including its target (ml_app, sampling, filter), LLM provider, and judge prompt template.

--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -309,7 +309,7 @@ The `llmobs` toolset includes the following tools:
 ### Trace and span tools
 
 `search_llmobs_spans`
-: Search for spans matching filters or a raw query.
+: Search for spans matching filters or a raw query. The raw query can include one feedback predicate of the form `@feedback.<label>.<field>:<value>`, combined with the rest of the query using `AND`, to return only the spans that received matching user feedback. The supported fields are `action`, `assessment`, `id`, `eval_metric_type`, `eval_scope`, `feedback_join_key`, `llm_output`, `reasoning`, `status`, and `value`. Every field matches on equality, `value` also accepts numeric comparison operators, and `*` matches any whole value to find the spans that have a given label at all. A query accepts only one feedback predicate, and negated or parenthesized feedback predicates, wildcards inside a value, and `OR` or `NOT` combinations with a feedback predicate are rejected. To discover which labels your users submitted, call `list_llmobs_feedback_labels` first, then search with a query such as `@ml_app:my-chatbot AND @feedback.helpfulness.value:<3`.
 
 `get_llmobs_trace`
 : Get the full structure of a trace as a span hierarchy tree, including span counts by kind, error indicators, and total duration.
@@ -356,6 +356,9 @@ The `llmobs` toolset includes the following tools:
 
 `list_llmobs_evals_by_ml_app`
 : List all LLM-judge evaluators configured for a specific ML application.
+
+`list_llmobs_feedback_labels`
+: List the feedback labels that users submitted for an ML application, rather than the evaluators configured for it. Returns the value types observed for each label, how many feedback events it received, and pass and fail counts when the label defines assessment criteria. Requires an ML application and a time range.
 
 `get_llmobs_evaluator`
 : Retrieve an LLM-judge evaluator configuration by name, including its target (ml_app, sampling, filter), LLM provider, and judge prompt template.

--- a/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
+++ b/hugo/content/en/llm_observability/build_with_ai/mcp_server.md
@@ -309,7 +309,7 @@ The `llmobs` toolset includes the following tools:
 ### Trace and span tools
 
 `search_llmobs_spans`
-: Search for spans matching filters or a raw query. The raw query can include one feedback predicate of the form `@feedback.<label>.<field>:<value>`, combined with the rest of the query using `AND`, to return only the spans that received matching user feedback. The supported fields are `action`, `assessment`, `id`, `eval_metric_type`, `eval_scope`, `feedback_join_key`, `llm_output`, `reasoning`, `status`, and `value`. Every field matches on equality, `value` also accepts numeric comparison operators, and `*` matches any whole value to find the spans that have a given label at all. A query accepts only one feedback predicate, and negated or parenthesized feedback predicates, wildcards inside a value, and `OR` or `NOT` combinations with a feedback predicate are rejected. To discover which labels your users submitted, call `list_llmobs_feedback_labels` first, then search with a query such as `@ml_app:my-chatbot AND @feedback.helpfulness.value:<3`.
+: Search for spans matching filters or a raw query.
 
 `get_llmobs_trace`
 : Get the full structure of a trace as a span hierarchy tree, including span counts by kind, error indicators, and total duration.
@@ -358,7 +358,7 @@ The `llmobs` toolset includes the following tools:
 : List all LLM-judge evaluators configured for a specific ML application.
 
 `list_llmobs_feedback_labels`
-: List the feedback labels that users submitted for an ML application, rather than the evaluators configured for it. Returns the value types observed for each label, how many feedback events it received, and pass and fail counts when the label defines assessment criteria. Requires an ML application and a time range.
+: List all the feedback labels that end users submitted for a specific ML application.
 
 `get_llmobs_evaluator`
 : Retrieve an LLM-judge evaluator configuration by name, including its target (ml_app, sampling, filter), LLM provider, and judge prompt template.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6481eebd-5a5c-4e25-97c2-49ac0566e039","source":"chat","resourceId":"9d0ffe1b-0417-4ab4-b038-02b73fdc0349","workflowId":"54576284-ef44-416c-8512-3b7b52f0371c","codeChangeId":"54576284-ef44-416c-8512-3b7b52f0371c","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The `llmobs` MCP toolset gained a tool for listing submitted feedback labels in https://github.com/ddoghq/dd-source/pull/80030, but the Agent Observability MCP page did not list it, so users had no way to learn it exists.

Changes:

- Added a `list_llmobs_feedback_labels` entry beside the evaluator-list tools, describing that it lists the feedback labels end users submitted for a specific ML application.

The entry matches the existing definition-list format and one-line length of the neighboring tool entries in the "Available tools" section, so no new headings or code blocks were introduced.

### Testing

Reviewed the rendered Markdown structure against the neighboring tool entries and checked the wording against the style substitutions in `CLAUDE.md` (Vale is not available in this environment, so it was not run locally).

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code, then reviewed manually.

### Additional notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9d0ffe1b-0417-4ab4-b038-02b73fdc0349)

Comment @datadog to request changes