### PR TITLE
Clarify Test Optimization environment variable guidance

### DIFF
--- a/hugo/content/en/tests/setup/dotnet.md
+++ b/hugo/content/en/tests/setup/dotnet.md
@@ -153,25 +153,14 @@ The following list shows the default values for key configuration settings:
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
-: Enables Agentless mode to send test results directly to Datadog.<br/>
-**Default**: `false`
-
-`DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
-**Default**: `(empty)`
-
-`DD_SITE` (Required for Agentless mode)
-: The [Datadog site][20] to upload test results to.<br/>
-**Default**: `datadoghq.com`
-
-`--agent-url` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is only needed when test results are reported through the Datadog Agent.<br/>
+`--agent-url`
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-`DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
+`test_session.name` (only available as an environment variable)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
@@ -427,4 +416,3 @@ Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary betwe
 [17]: https://github.com/microsoft/codecoverage/blob/main/samples/Calculator/scenarios/scenario07/README.md
 [18]: /tracing/trace_collection/compatibility/dotnet-framework/
 [19]: /tracing/trace_collection/compatibility/dotnet-core/
-[20]: /getting_started/site/

--- a/hugo/content/en/tests/setup/dotnet.md
+++ b/hugo/content/en/tests/setup/dotnet.md
@@ -74,7 +74,7 @@ Install or update the `dd-trace` command using one of the following ways:
 
 <div class="alert alert-warning">For BenchmarkDotNet follow <a href="#instrumenting-benchmarkdotnet-tests">these instructions</a>.</div>
 
-To instrument your test suite, prefix your test command with `dd-trace ci run`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
+To instrument your test suite, prefix your test command with `dd-trace ci run`. You can use `--dd-service` to set the service or library under test and `--dd-env` to set the environment where tests are run. For example:
 
 {{< tabs >}}
 
@@ -141,27 +141,27 @@ dd-trace ci run --help
 
 The following list shows the default values for key configuration settings:
 
-`--dd-service`
+`--dd-service` (Optional)
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
 **Default**: The repository name<br/>
 **Example**: `my-dotnet-app`
 
-`--dd-env`
+`--dd-env` (Optional)
 : Name of the environment where tests are being run.<br/>
 **Environment variable**: `DD_ENV`<br/>
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`--agent-url`
-: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+`--agent-url` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
 `test_session.name` (only available as an environment variable)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
 **Environment variable**: `DD_TEST_SESSION_NAME`<br/>
-**Default**: (CI job name + test command)<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][6]. All other [Datadog Tracer configuration][7] options can also be used.
@@ -377,10 +377,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
-
-- CI job name
-- Command used to run the tests (such as `yarn test`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the CI job name and test command. If the CI job name is unavailable, the test command is used.
 
 The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/content/en/tests/setup/dotnet.md
+++ b/hugo/content/en/tests/setup/dotnet.md
@@ -170,9 +170,8 @@ The following list shows the default values for key configuration settings:
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-`test_session.name` (only available as an environment variable)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
+`DD_TEST_SESSION_NAME` (Optional)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 

--- a/hugo/content/en/tests/setup/dotnet.md
+++ b/hugo/content/en/tests/setup/dotnet.md
@@ -153,8 +153,20 @@ The following list shows the default values for key configuration settings:
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`--agent-url`
-: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
+
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site][20] to upload test results to.<br/>
+**Default**: `datadoghq.com`
+
+`--agent-url` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is only needed when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
@@ -416,3 +428,4 @@ Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary betwe
 [17]: https://github.com/microsoft/codecoverage/blob/main/samples/Calculator/scenarios/scenario07/README.md
 [18]: /tracing/trace_collection/compatibility/dotnet-framework/
 [19]: /tracing/trace_collection/compatibility/dotnet-core/
+[20]: /getting_started/site/

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -112,6 +112,20 @@ Set the following environment variables to configure the library:
 `DD_ENV` (Required)
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.
+
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site](/getting_started/site/) to upload test results to.<br/>
+**Default**: `datadoghq.com`
+
+`DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+**Default**: `http://localhost:8126`
+
 Prefix your go test command with `orchestrion`:
 
 ```bash

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -106,36 +106,43 @@ In addition to this, Orchestrion only supports projects using [Go modules][go-mo
 
 Set the following environment variables to configure the library:
 
+When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
+
 `DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
+: Enables Test Optimization.<br/>
+**Default**: `false`
 
 `DD_SERVICE` (Optional)
 : Name of the service or library under test.<br/>
-**Default**: The repository name. If unavailable, the executable name.
+**Default**: The repository name
 
-`DD_ENV` (Required)
-: Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
+`DD_ENV` (Optional)
+: Name of the environment where tests are being run.<br/>
+**Default**: `(empty)`<br/>
+**Examples**: `local`, `ci`
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
 : Enables Agentless mode to send test results directly to Datadog.<br/>
 **Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
-: The [Datadog site][2] to upload test results to. Set this variable when using a site other than US1.<br/>
+: The [Datadog site][2] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Default**: (CI job name + test command)<br/>
-**Example**: `unit-tests`
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 Prefix your go test command with `orchestrion`:
 

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -126,6 +126,11 @@ Set the following environment variables to configure the library:
 : The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
+`DD_TEST_SESSION_NAME` (Optional)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
+**Default**: (CI job name + test command)<br/>
+**Example**: `unit-tests`
+
 Prefix your go test command with `orchestrion`:
 
 ```bash

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -109,6 +109,10 @@ Set the following environment variables to configure the library:
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
 
+`DD_SERVICE` (Optional)
+: Name of the service or library under test.<br/>
+**Default**: The repository name. If unavailable, the executable name.
+
 `DD_ENV` (Required)
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -113,17 +113,19 @@ Set the following environment variables to configure the library:
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
-: Enables Agentless mode to send test results directly to Datadog.
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
 : The [Datadog site][2] to upload test results to. Set this variable when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_TEST_SESSION_NAME` (Optional)

--- a/hugo/content/en/tests/setup/go.md
+++ b/hugo/content/en/tests/setup/go.md
@@ -118,8 +118,8 @@ Set the following environment variables to configure the library:
 `DD_API_KEY` (Required for Agentless mode)
 : The Datadog API key used to upload test results.
 
-`DD_SITE` (Required for Agentless mode)
-: The [Datadog site](/getting_started/site/) to upload test results to.<br/>
+`DD_SITE` (Optional for Agentless mode)
+: The [Datadog site][2] to upload test results to. Set this variable when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
@@ -167,6 +167,7 @@ $ go test -toolexec 'orchestrion toolexec' -race .
 ```
 
 [1]: https://github.com/datadog/orchestrion
+[2]: /getting_started/site/
 
 ## Further reading
 {{< partial name="whats-next/whats-next.html" >}}

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -117,24 +117,28 @@ Set the following environment variables to configure the SDK and its reporting m
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
-: Enables Agentless mode to send test results directly to Datadog.
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
 : The [Datadog site][4] to upload test results to. Set this variable when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_SERVICE`
 : Name of the service or library being tested.
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
+: Identifies a group of tests, such as `unit-tests` or `integration-tests`.<br/>
+**Default**: (CI job name + test command)<br/>
+**Example**: `unit-tests`
 
 Set the following environment variables for your build tool:
 

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -108,10 +108,7 @@ You can run the `java -jar $DD_TRACER_FOLDER/dd-java-agent.jar` command to check
 
 ### Running your tests
 
-{{< tabs >}}
-{{% tab "Maven" %}}
-
-Set the following environment variables to configure the SDK:
+Set the following environment variables to configure the SDK and its reporting method:
 
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
@@ -119,8 +116,30 @@ Set the following environment variables to configure the SDK:
 `DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.
+
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site](/getting_started/site/) to upload test results to.<br/>
+**Default**: `datadoghq.com`
+
+`DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+**Default**: `http://localhost:8126`
+
 `DD_SERVICE`
 : Name of the service or library being tested.
+
+`DD_TEST_SESSION_NAME`
+: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
+
+Set the following environment variables for your build tool:
+
+{{< tabs >}}
+{{% tab "Maven" %}}
 
 `DD_TRACER_FOLDER` (Required)
 : Path to the folder where the downloaded Java Tracer is located.
@@ -128,24 +147,10 @@ Set the following environment variables to configure the SDK:
 `MAVEN_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
 : Injects the SDK into the Maven build process.
 
-`DD_TEST_SESSION_NAME`
-: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
-
 Run your tests as you normally do (for example: `mvn test` or `mvn verify`).
 
 {{% /tab %}}
 {{% tab "Gradle" %}}
-
-Set the following environment variables to configure the SDK:
-
-`DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
-
-`DD_ENV`
-: Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
-
-`DD_SERVICE`
-: Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
 : Path to the folder where the downloaded Java Tracer is located.
@@ -158,20 +163,6 @@ Run your tests as you normally do (for example: `./gradlew clean test`).
 {{% /tab %}}
 {{% tab "SBT" %}}
 
-Set the following environment variables to configure the SDK:
-
-`DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
-
-`DD_TEST_SESSION_NAME`
-: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
-
-`DD_ENV`
-: Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
-
-`DD_SERVICE`
-: Name of the service or library being tested.
-
 `DD_TRACER_FOLDER` (Required)
 : Path to the folder where the downloaded Java Tracer is located.
 
@@ -182,20 +173,6 @@ Run your tests as you normally do (for example: `sbt test`).
 
 {{% /tab %}}
 {{% tab "Other" %}}
-
-Set the following environment variables to configure the SDK:
-
-`DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
-
-`DD_TEST_SESSION_NAME`
-: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
-
-`DD_ENV`
-: Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
-
-`DD_SERVICE`
-: Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
 : Path to the folder where the downloaded Java Tracer is located.

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -122,8 +122,8 @@ Set the following environment variables to configure the SDK and its reporting m
 `DD_API_KEY` (Required for Agentless mode)
 : The Datadog API key used to upload test results.
 
-`DD_SITE` (Required for Agentless mode)
-: The [Datadog site](/getting_started/site/) to upload test results to.<br/>
+`DD_SITE` (Optional for Agentless mode)
+: The [Datadog site][4] to upload test results to. Set this variable when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
@@ -552,6 +552,7 @@ To disable all integrations, augment the list of `-javaagent` arguments with `dd
 [1]: #using-manual-testing-api
 [2]: https://app.datadoghq.com/ci/setup/test?language=java
 [3]: /tracing/trace_collection/library_config/java/?tab=containers#configuration
+[4]: /getting_started/site/
 [6]: /tests/guides/add_custom_measures/?tab=java
 [7]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
 [8]: /tests/#parameterized-test-configurations

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -108,9 +108,50 @@ You can run the `java -jar $DD_TRACER_FOLDER/dd-java-agent.jar` command to check
 
 ### Running your tests
 
-Set the following environment variables to configure the SDK and its reporting method:
-
 When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
+
+First, set the following required environment variables for your build tool:
+
+{{< tabs >}}
+{{% tab "Maven" %}}
+
+`DD_TRACER_FOLDER` (Required)
+: Path to the folder where the downloaded Java Tracer is located.
+
+`MAVEN_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
+: Injects the SDK into the Maven build process.
+
+{{% /tab %}}
+{{% tab "Gradle" %}}
+
+`DD_TRACER_FOLDER` (Required)
+: Path to the folder where the downloaded Java Tracer is located.
+
+`GRADLE_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
+: Injects the SDK into the Gradle launcher process.
+
+{{% /tab %}}
+{{% tab "SBT" %}}
+
+`DD_TRACER_FOLDER` (Required)
+: Path to the folder where the downloaded Java Tracer is located.
+
+`SBT_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
+: Injects the SDK into the JVMs that execute your tests.
+
+{{% /tab %}}
+{{% tab "Other" %}}
+
+`DD_TRACER_FOLDER` (Required)
+: Path to the folder where the downloaded Java Tracer is located.
+
+`JAVA_TOOL_OPTIONS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
+: Injects the SDK into the JVMs that execute your tests.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Then, set the following common environment variables to configure the SDK and its reporting method:
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
 
@@ -148,54 +189,7 @@ When using environment variables, set them before starting the test process. For
 **Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
-Set the following environment variables for your build tool:
-
-{{< tabs >}}
-{{% tab "Maven" %}}
-
-`DD_TRACER_FOLDER` (Required)
-: Path to the folder where the downloaded Java Tracer is located.
-
-`MAVEN_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
-: Injects the SDK into the Maven build process.
-
-Run your tests as you normally do (for example: `mvn test` or `mvn verify`).
-
-{{% /tab %}}
-{{% tab "Gradle" %}}
-
-`DD_TRACER_FOLDER` (Required)
-: Path to the folder where the downloaded Java Tracer is located.
-
-`GRADLE_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
-: Injects the SDK into the Gradle launcher process.
-
-Run your tests as you normally do (for example: `./gradlew clean test`).
-
-{{% /tab %}}
-{{% tab "SBT" %}}
-
-`DD_TRACER_FOLDER` (Required)
-: Path to the folder where the downloaded Java Tracer is located.
-
-`SBT_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
-: Injects the SDK into the JVMs that execute your tests.
-
-Run your tests as you normally do (for example: `sbt test`).
-
-{{% /tab %}}
-{{% tab "Other" %}}
-
-`DD_TRACER_FOLDER` (Required)
-: Path to the folder where the downloaded Java Tracer is located.
-
-`JAVA_TOOL_OPTIONS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
-: Injects the SDK into the JVMs that execute your tests.
-
-Run your tests as you normally do.
-
-{{% /tab %}}
-{{< /tabs >}}
+Run your tests as you normally do (for example: `mvn test`, `mvn verify`, `./gradlew clean test`, or `sbt test`).
 
 ## Configuration
 

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -133,7 +133,8 @@ Set the following environment variables to configure the SDK and its reporting m
 **Default**: `http://localhost:8126`
 
 `DD_SERVICE`
-: Name of the service or library being tested.
+: Name of the service or library under test.<br/>
+**Default**: `unnamed-java-app`
 
 `DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests, such as `unit-tests` or `integration-tests`.<br/>

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -133,7 +133,7 @@ Set the following environment variables to configure the SDK and its reporting m
 `DD_SERVICE`
 : Name of the service or library being tested.
 
-`DD_TEST_SESSION_NAME`
+`DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
 
 Set the following environment variables for your build tool:

--- a/hugo/content/en/tests/setup/java.md
+++ b/hugo/content/en/tests/setup/java.md
@@ -110,36 +110,43 @@ You can run the `java -jar $DD_TRACER_FOLDER/dd-java-agent.jar` command to check
 
 Set the following environment variables to configure the SDK and its reporting method:
 
-`DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
+When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
 
-`DD_ENV`
-: Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
+
+`DD_CIVISIBILITY_ENABLED=true` (Required)
+: Enables Test Optimization.<br/>
+**Default**: `false`
+
+`DD_ENV` (Optional)
+: Name of the environment where tests are being run.<br/>
+**Default**: `(empty)`<br/>
+**Examples**: `local`, `ci`
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
 : Enables Agentless mode to send test results directly to Datadog.<br/>
 **Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
-: The [Datadog site][4] to upload test results to. Set this variable when using a site other than US1.<br/>
+: The [Datadog site][4] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
-`DD_SERVICE`
+`DD_SERVICE` (Optional)
 : Name of the service or library under test.<br/>
 **Default**: `unnamed-java-app`
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests, such as `unit-tests` or `integration-tests`.<br/>
-**Default**: (CI job name + test command)<br/>
-**Example**: `unit-tests`
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 Set the following environment variables for your build tool:
 
@@ -483,10 +490,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
-
-- CI job name
-- Command used to run the tests (such as `mvn test`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the CI job name and test command. If the CI job name is unavailable, the test command is used.
 
 The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -638,16 +638,20 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+`agentless` (Required for Agentless mode)
 : Enables Agentless mode to send test results directly to Datadog.<br/>
-**Default**: `false`
+**Environment variable**: `DD_CIVISIBILITY_AGENTLESS_ENABLED`<br/>
+**Default**: `false`<br/>
+**Example**: `true`
 
-`DD_API_KEY` (Required for Agentless mode)
+`api_key` (Required for Agentless mode)
 : The Datadog API key used to upload test results.<br/>
+**Environment variable**: `DD_API_KEY`<br/>
 **Default**: `(empty)`
 
-`DD_SITE` (Required for Agentless mode)
+`site` (Required for Agentless mode)
 : The [Datadog site][25] to upload test results to.<br/>
+**Environment variable**: `DD_SITE`<br/>
 **Default**: `datadoghq.com`
 
 `url` (Only when using the Datadog Agent)
@@ -655,9 +659,9 @@ The following is a list of the most important configuration settings that can be
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-`DD_TEST_SESSION_NAME` (Optional)
+`test_session.name`
 : Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Configuration setting**: `test_session.name`<br/>
+**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`. For `dd-trace` v5, a combination of CI job name and test command.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -626,12 +626,6 @@ For more information, see [Code Coverage][6].
 
 The following is a list of the most important configuration settings that can be used with the SDK.
 
-`test_session.name`
-: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
-**Default**: For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`. For `dd-trace` v5, a combination of CI job name and test command.<br/>
-**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
-
 `service`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
@@ -660,6 +654,12 @@ The following is a list of the most important configuration settings that can be
 : The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is only needed when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
+
+`DD_TEST_SESSION_NAME` (Optional)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
+**Configuration setting**: `test_session.name`<br/>
+**Default**: For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`. For `dd-trace` v5, a combination of CI job name and test command.<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][7]. All other [Datadog Tracer configuration][8] options can also be used.
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -629,7 +629,7 @@ The following is a list of the most important configuration settings that can be
 `service`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: For `dd-trace` v6, the Nx project name when available. Otherwise, the nearest `package.json` package name, or `node` if unavailable.<br/>
+**Default**: The Nx project name when available. Otherwise, the name in the nearest `package.json`, or `node` if unavailable.<br/>
 **Example**: `my-ui`
 
 `env`
@@ -662,7 +662,7 @@ The following settings are available only as environment variables:
 
 `DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Default**: For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`. For `dd-trace` v5, a combination of CI job name and test command.<br/>
+**Default**: The Lage package name when available. Otherwise, the CI job name and framework command, or the framework command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][7]. All other [Datadog Tracer configuration][8] options can also be used.

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -644,7 +644,7 @@ The following is a list of the most important configuration settings that can be
 **Default**: `datadoghq.com`
 
 `url` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is only needed when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is needed only when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -666,7 +666,7 @@ The following settings are available only as environment variables:
 
 `DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
-**Default**: The Lage package name when available. Otherwise, the CI job name and framework command, or the framework command if the CI job name is unavailable.<br/>
+**Default**: When tests run with [Lage][26], the Lage package name. Otherwise, the CI job name and framework command, or the framework command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][7]. All other [Datadog Tracer configuration][8] options can also be used.
@@ -968,7 +968,10 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default is the Lage package name when available. Otherwise, the default is the CI job name and framework command. If the CI job name is unavailable, the framework command is used.
+If `DD_TEST_SESSION_NAME` is not specified:
+
+- When tests run with [Lage][26], the default is the Lage package name (for example, `my-package`).
+- Otherwise, the default is the CI job name and framework command (for example, `unit-tests-jest`). If the CI job name is unavailable, the framework command is used (for example, `jest`).
 
 The test session name should be unique within a repository to help you distinguish different groups of tests.
 
@@ -997,3 +1000,4 @@ The test session name should be unique within a repository to help you distingui
 [23]: /tests/flaky_tests/auto_test_retries/
 [24]: /tests/flaky_management/#confirm-fixes-for-flaky-tests
 [25]: /getting_started/site/
+[26]: https://microsoft.github.io/lage/docs/introduction

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -644,8 +644,20 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`url`
-: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
+
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site][25] to upload test results to.<br/>
+**Default**: `datadoghq.com`
+
+`url` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is only needed when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
@@ -979,3 +991,4 @@ The test session name should be unique within a repository to help you distingui
 [22]: /tests/flaky_tests/early_flake_detection/
 [23]: /tests/flaky_tests/auto_test_retries/
 [24]: /tests/flaky_management/#confirm-fixes-for-flaky-tests
+[25]: /getting_started/site/

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -629,7 +629,7 @@ The following is a list of the most important configuration settings that can be
 `service`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: (test framework name)<br/>
+**Default**: For `dd-trace` v6, the Nx project name when available. Otherwise, the nearest `package.json` package name, or `node` if unavailable.<br/>
 **Example**: `my-ui`
 
 `env`

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -638,17 +638,6 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`agentless` (Required for Agentless mode)
-: Enables Agentless mode to send test results directly to Datadog.<br/>
-**Environment variable**: `DD_CIVISIBILITY_AGENTLESS_ENABLED`<br/>
-**Default**: `false`<br/>
-**Example**: `true`
-
-`api_key` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
-**Environment variable**: `DD_API_KEY`<br/>
-**Default**: `(empty)`
-
 `site` (Required for Agentless mode)
 : The [Datadog site][25] to upload test results to.<br/>
 **Environment variable**: `DD_SITE`<br/>
@@ -659,9 +648,20 @@ The following is a list of the most important configuration settings that can be
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-`test_session.name`
+### Environment variables
+
+The following settings are available only as environment variables:
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
+
+`DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`. For `dd-trace` v5, a combination of CI job name and test command.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -626,27 +626,31 @@ For more information, see [Code Coverage][6].
 
 The following is a list of the most important configuration settings that can be used with the SDK.
 
-`service`
+When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
+
+`service` (Optional)
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: The Nx project name when available. Otherwise, the name in the nearest `package.json`, or `node` if unavailable.<br/>
+**Default**: The Nx project name<br/>
 **Example**: `my-ui`
 
-`env`
+`env` (Optional)
 : Name of the environment where tests are being run.<br/>
 **Environment variable**: `DD_ENV`<br/>
-**Default**: `none`<br/>
+**Default**: `(empty)`<br/>
 **Examples**: `local`, `ci`
 
 `site` (Optional for Agentless mode)
-: The [Datadog site][25] to upload test results to. Set this value when using a site other than US1.<br/>
+: The [Datadog site][25] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Environment variable**: `DD_SITE`<br/>
 **Default**: `datadoghq.com`
 
 `url` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This setting is needed only when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
-**Default**: `http://localhost:8126`
+**Default**: `http://127.0.0.1:8126`
 
 ### Environment variables
 
@@ -657,11 +661,11 @@ The following settings are available only as environment variables:
 **Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
 **Default**: The Lage package name when available. Otherwise, the CI job name and framework command, or the framework command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
@@ -964,10 +968,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value is:
-
-- For `dd-trace` v6, the framework invocation, such as `jest`, `mocha`, `playwright test`, or `cucumber-js`
-- For `dd-trace` v5, a combination of the CI job name and the command used to run the tests (for example, `my-ci-job yarn test`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the Lage package name when available. Otherwise, the default is the CI job name and framework command. If the CI job name is unavailable, the framework command is used.
 
 The test session name should be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/content/en/tests/setup/javascript.md
+++ b/hugo/content/en/tests/setup/javascript.md
@@ -638,8 +638,8 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`site` (Required for Agentless mode)
-: The [Datadog site][25] to upload test results to.<br/>
+`site` (Optional for Agentless mode)
+: The [Datadog site][25] to upload test results to. Set this value when using a site other than US1.<br/>
 **Environment variable**: `DD_SITE`<br/>
 **Default**: `datadoghq.com`
 

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -385,7 +385,7 @@ The following list contains key configuration settings and environment variables
 `DD_SERVICE`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: `pytest`<br/>
+**Default**: The repository name. If unavailable, `test` for the current pytest plugin, `pytest` for the legacy pytest plugin, or `unittest` for unittest.<br/>
 **Example**: `my-python-app`
 
 `DD_ENV`

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -380,7 +380,7 @@ For additional configurations, see [Configuration Settings][2].
 
 ## Configuration settings
 
-The following is a list of the most important configuration settings that can be used with the SDK, either in code or using environment variables:
+The following list contains key configuration settings and environment variables for the SDK and its reporting method:
 
 `DD_TEST_SESSION_NAME`
 : Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
@@ -400,13 +400,23 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-For more information about `service` and `env` reserved tags, see [Unified Service Tagging][2].
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.<br/>
+**Default**: `false`
 
-The following environment variable can be used to configure the location of the Datadog Agent:
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.<br/>
+**Default**: `(empty)`
 
-`DD_TRACE_AGENT_URL`
-: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site][4] to upload test results to.<br/>
+**Default**: `datadoghq.com`
+
+`DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
+
+For more information about `service` and `env` reserved tags, see [Unified Service Tagging][2].
 
 All other [Datadog Tracer configuration][3] options can also be used.
 
@@ -491,3 +501,4 @@ Datadog recommends you use up to one process at a time to prevent affecting test
 [1]: /tracing/trace_collection/dd_libraries/python/
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /tracing/trace_collection/library_config/python/?tab=containers#configuration
+[4]: /getting_started/site/

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -402,8 +402,8 @@ The following list contains key configuration settings and environment variables
 : The Datadog API key used to upload test results.<br/>
 **Default**: `(empty)`
 
-`DD_SITE` (Required for Agentless mode)
-: The [Datadog site][4] to upload test results to.<br/>
+`DD_SITE` (Optional for Agentless mode)
+: The [Datadog site][4] to upload test results to. Set this variable when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -407,12 +407,11 @@ The following list contains key configuration settings and environment variables
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_TEST_SESSION_NAME` (Optional)
 : Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -382,13 +382,17 @@ For additional configurations, see [Configuration Settings][2].
 
 The following list contains key configuration settings and environment variables for the SDK and its reporting method:
 
-`DD_SERVICE`
+When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
+
+`DD_SERVICE` (Optional)
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: The repository name. If unavailable, `test` for pytest or `unittest` for unittest.<br/>
+**Default**: The repository name<br/>
 **Example**: `my-python-app`
 
-`DD_ENV`
+`DD_ENV` (Optional)
 : Name of the environment where tests are being run.<br/>
 **Environment variable**: `DD_ENV`<br/>
 **Default**: `none`<br/>
@@ -399,20 +403,20 @@ The following list contains key configuration settings and environment variables
 **Default**: `false`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.<br/>
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
-: The [Datadog site][4] to upload test results to. Set this variable when using a site other than US1.<br/>
+: The [Datadog site][4] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
-**Default**: (CI job name + test command)<br/>
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][2].
@@ -436,10 +440,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
-
-- CI job name
-- Command used to run the tests (such as `pytest --ddtrace`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the CI job name and test command. If the CI job name is unavailable, the test command is used.
 
 The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -385,7 +385,7 @@ The following list contains key configuration settings and environment variables
 `DD_SERVICE`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
-**Default**: The repository name. If unavailable, `test` for the current pytest plugin, `pytest` for the legacy pytest plugin, or `unittest` for unittest.<br/>
+**Default**: The repository name. If unavailable, `test` for pytest or `unittest` for unittest.<br/>
 **Example**: `my-python-app`
 
 `DD_ENV`

--- a/hugo/content/en/tests/setup/python.md
+++ b/hugo/content/en/tests/setup/python.md
@@ -382,12 +382,6 @@ For additional configurations, see [Configuration Settings][2].
 
 The following list contains key configuration settings and environment variables for the SDK and its reporting method:
 
-`DD_TEST_SESSION_NAME`
-: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
-**Default**: (CI job name + test command)<br/>
-**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
-
 `DD_SERVICE`
 : Name of the service or library under test.<br/>
 **Environment variable**: `DD_SERVICE`<br/>
@@ -415,6 +409,12 @@ The following list contains key configuration settings and environment variables
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
 : The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
+
+`DD_TEST_SESSION_NAME` (Optional)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests`, or `smoke-tests`.<br/>
+**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
+**Default**: (CI job name + test command)<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][2].
 

--- a/hugo/content/en/tests/setup/ruby.md
+++ b/hugo/content/en/tests/setup/ruby.md
@@ -127,7 +127,7 @@ The following environment variables configure the test optimization library and 
 
 `DD_SERVICE` (Optional)
 : Name of the service or library under test.
-**Default**: `$PROGRAM_NAME`<br/>
+**Default**: The repository name. If unavailable, the test framework name.<br/>
 **Example**: `my-ruby-app`
 
 `DD_TEST_SESSION_NAME` (Optional)

--- a/hugo/content/en/tests/setup/ruby.md
+++ b/hugo/content/en/tests/setup/ruby.md
@@ -99,40 +99,44 @@ bundle exec ddcirb exec rspec
 
 The following environment variables configure the test optimization library and its reporting method:
 
+When using environment variables, set them before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` selects Agentless transport. `DD_API_KEY` provides authentication but does not enable Agentless mode.
+
 `DD_CIVISIBILITY_ENABLED=true` (Required)
-: Enables the Test Optimization product.
+: Enables Test Optimization.<br/>
 **Default**: `false`
 
-`DD_ENV` (Required)
-: Environment where the tests are being run (`ci` when running them on a CI provider).
-**Default**: `none`
-**Example**: `ci`
+`DD_ENV` (Optional)
+: Name of the environment where tests are being run.<br/>
+**Default**: `(empty)`<br/>
+**Examples**: `local`, `ci`
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
-: Enables Agentless mode to send test results directly to Datadog.
+: Enables Agentless mode to send test results directly to Datadog.<br/>
 **Default**: `false`
-**Example**: `true`
 
 `DD_API_KEY` (Required for Agentless mode)
-: The Datadog API key used to upload test results.
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 `DD_SITE` (Optional for Agentless mode)
-: The [Datadog site][11] to upload test results to. Set this variable when using a site other than US1.
+: The [Datadog site][11] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
-**Default**: `http://localhost:8126`
+: The Datadog Agent URL for trace collection, in the form `http://hostname:port`. This configuration is used only when test results are reported through the Datadog Agent.<br/>
+**Default**: `http://127.0.0.1:8126`
 
 `DD_SERVICE` (Optional)
-: Name of the service or library under test.
-**Default**: The repository name. If unavailable, the test framework name.<br/>
+: Name of the service or library under test.<br/>
+**Default**: The repository name<br/>
 **Example**: `my-ruby-app`
 
 `DD_TEST_SESSION_NAME` (Optional)
-: Use this to identify a group of tests (see ["Test session name"](#test-session-name-dd_test_session_name))
-**Example**: `integration-tests`
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 All other [Datadog Tracer configuration][5] options can also be used.
 
@@ -296,10 +300,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 -   `ui-tests`
 -   `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
-
--   CI job name
--   Command used to run the tests (such as `yarn test`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the CI job name and test command. If the CI job name is unavailable, the test command is used.
 
 The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/content/en/tests/setup/ruby.md
+++ b/hugo/content/en/tests/setup/ruby.md
@@ -117,8 +117,8 @@ The following environment variables configure the test optimization library and 
 : The Datadog API key used to upload test results.
 **Default**: `(empty)`
 
-`DD_SITE` (Required for Agentless mode)
-: The [Datadog site][11] to upload test results to.
+`DD_SITE` (Optional for Agentless mode)
+: The [Datadog site][11] to upload test results to. Set this variable when using a site other than US1.
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)

--- a/hugo/content/en/tests/setup/ruby.md
+++ b/hugo/content/en/tests/setup/ruby.md
@@ -109,7 +109,7 @@ The following environment variables configure the test optimization library and 
 **Example**: `ci`
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
-: Enables Agentless mode to send data directly to Datadog without a Datadog Agent. Requires `DD_API_KEY` to be set.
+: Enables Agentless mode to send test results directly to Datadog.
 **Default**: `false`
 **Example**: `true`
 
@@ -122,7 +122,7 @@ The following environment variables configure the test optimization library and 
 **Default**: `datadoghq.com`
 
 `DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
-: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is needed only when test results are reported through the Datadog Agent.<br/>
 **Default**: `http://localhost:8126`
 
 `DD_SERVICE` (Optional)

--- a/hugo/content/en/tests/setup/ruby.md
+++ b/hugo/content/en/tests/setup/ruby.md
@@ -97,7 +97,7 @@ bundle exec ddcirb exec rspec
 
 ## Configuration settings
 
-The following is a list of the most important configuration settings that can be used with the test optimization library:
+The following environment variables configure the test optimization library and its reporting method:
 
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
@@ -108,6 +108,23 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`
 **Example**: `ci`
 
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send data directly to Datadog without a Datadog Agent. Requires `DD_API_KEY` to be set.
+**Default**: `false`
+**Example**: `true`
+
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to upload test results.
+**Default**: `(empty)`
+
+`DD_SITE` (Required for Agentless mode)
+: The [Datadog site][11] to upload test results to.
+**Default**: `datadoghq.com`
+
+`DD_TRACE_AGENT_URL` (Only when using the Datadog Agent)
+: The Datadog Agent URL for trace collection in the form `http://hostname:port`. This variable is only needed when test results are reported through the Datadog Agent.<br/>
+**Default**: `http://localhost:8126`
+
 `DD_SERVICE` (Optional)
 : Name of the service or library under test.
 **Default**: `$PROGRAM_NAME`<br/>
@@ -116,17 +133,6 @@ The following is a list of the most important configuration settings that can be
 `DD_TEST_SESSION_NAME` (Optional)
 : Use this to identify a group of tests (see ["Test session name"](#test-session-name-dd_test_session_name))
 **Example**: `integration-tests`
-
-The following environment variables can be used to configure tests reporting:
-
-`DD_TRACE_AGENT_URL`
-: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
-**Default**: `http://localhost:8126`
-
-`DD_CIVISIBILITY_AGENTLESS_ENABLED`
-: Enables agentless mode to send data directly to Datadog without a Datadog agent. Requires `DD_API_KEY` to be set.
-**Default**: `false`
-**Example**: `true`
 
 All other [Datadog Tracer configuration][5] options can also be used.
 
@@ -318,3 +324,4 @@ Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary betwe
 [8]: https://datadoghq.dev/datadog-ci-rb/Datadog/CI.html
 [9]: https://github.com/vcr/vcr
 [10]: https://github.com/DataDog/datadog-ci-rb
+[11]: /getting_started/site/

--- a/hugo/content/en/tests/setup/swift.md
+++ b/hugo/content/en/tests/setup/swift.md
@@ -178,26 +178,25 @@ Set all these variables in your test target:
 **Default**: `false`<br/>
 **Recommended**: `$(DD_TEST_RUNNER)`
 
-`DD_API_KEY`
-: The [Datadog API key][2] used to upload the test results.<br/>
+`DD_API_KEY` (Required)
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
-`DD_TEST_SESSION_NAME`
-: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
-**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
-**Default**: (CI job name + test command)<br/>
+`DD_TEST_SESSION_NAME` (Optional)
+: Identifies a group of tests, such as `unit-tests`, `integration-tests`, or `smoke-tests`.<br/>
+**Default**: The CI job name and test command, or the test command if the CI job name is unavailable.<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
-`DD_SERVICE`
+`DD_SERVICE` (Optional)
 : Name of the service or library under test.<br/>
 **Default**: The repository name<br/>
 **Example**: `my-ios-app`
 
-`DD_ENV`
-: Name of the environment where tests are being run. Set this value to `$(DD_ENV)` so you can use an environment variable at runtime for setting it.<br/>
-**Default**: `none`<br/>
+`DD_ENV` (Optional)
+: Name of the environment where tests are being run.<br/>
+**Default**: `ci` when a CI provider is detected; otherwise, `none`.<br/>
 **Recommended**: `$(DD_ENV)`<br/>
-**Examples**: `ci`, `local`
+**Examples**: `local`, `ci`
 
 `SRCROOT`
 : The path to the project location. If using Xcode, use `$(SRCROOT)` for the value, because it is automatically set by it.<br/>
@@ -209,8 +208,8 @@ For more information about `service` and `env` reserved tags, see [Unified Servi
 
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
-`DD_SITE` (Required)
-: The [Datadog site][3] to upload results to.<br/>
+`DD_SITE` (Optional)
+: The [Datadog site][3] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
 
@@ -667,10 +666,7 @@ Use `DD_TEST_SESSION_NAME` to define the name of the test session and the relate
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
-
-- CI job name
-- Command used to run the tests (such as `swift test`)
+If `DD_TEST_SESSION_NAME` is not specified, the default is the CI job name and test command. If the CI job name is unavailable, the test command is used.
 
 The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 

--- a/hugo/layouts/shortcodes/ci-agentless.en.md
+++ b/hugo/layouts/shortcodes/ci-agentless.en.md
@@ -8,7 +8,7 @@ If you are using a cloud CI provider without access to the underlying worker nod
 : The [Datadog API key][101] used to upload the test results.<br/>
 **Default**: `(empty)`
 
-If you use a Datadog site other than US1, configure the site to which you want to send data.
+If you use a Datadog site other than US1, set the following variable:
 
 `DD_SITE` (Optional)
 : The [Datadog site][102] to upload results to.<br/>

--- a/hugo/layouts/shortcodes/ci-agentless.en.md
+++ b/hugo/layouts/shortcodes/ci-agentless.en.md
@@ -8,9 +8,9 @@ If you are using a cloud CI provider without access to the underlying worker nod
 : The [Datadog API key][101] used to upload the test results.<br/>
 **Default**: `(empty)`
 
-Additionally, configure the [Datadog site][102] to which you want to send data.
+If you use a Datadog site other than US1, configure the site to which you want to send data.
 
-`DD_SITE` (Required)
+`DD_SITE` (Optional)
 : The [Datadog site][102] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 

--- a/hugo/layouts/shortcodes/ci-agentless.en.md
+++ b/hugo/layouts/shortcodes/ci-agentless.en.md
@@ -1,19 +1,23 @@
 If you are using a cloud CI provider without access to the underlying worker nodes, such as GitHub Actions or CircleCI, configure the library to use the Agentless mode. For this, set the following environment variables:
 
-`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required)
-: Enables or disables Agentless mode.<br/>
+<div class="alert alert-warning">
+<p>Set these variables before starting the test process. For parallel test runners, set them on the parent process so every worker inherits them.</p>
+<p><code>DD_CIVISIBILITY_AGENTLESS_ENABLED=true</code> selects Agentless transport. <code>DD_API_KEY</code> provides authentication but does not enable Agentless mode.</p>
+</div>
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required for Agentless mode)
+: Enables Agentless mode to send test results directly to Datadog.<br/>
 **Default**: `false`
 
-`DD_API_KEY` (Required)
-: The [Datadog API key][101] used to upload the test results.<br/>
+`DD_API_KEY` (Required for Agentless mode)
+: The Datadog API key used to authenticate test result uploads.<br/>
 **Default**: `(empty)`
 
 If you use a Datadog site other than US1, set the following variable:
 
-`DD_SITE` (Optional)
-: The [Datadog site][102] to upload results to.<br/>
+`DD_SITE` (Optional for Agentless mode)
+: The [Datadog site][102] to upload test results to. Set this configuration when using a site other than US1.<br/>
 **Default**: `datadoghq.com`<br/>
 
 
-[101]: https://app.datadoghq.com/organization-settings/api-keys
 [102]: /getting_started/site/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The Test Optimization setup guides separated Agentless environment variables from the primary manual configuration. This could make `DD_CIVISIBILITY_AGENTLESS_ENABLED` appear not important even though it is required to select agentless  mode. 

The configuration lists also presented `DD_TRACE_AGENT_URL` without saying that it is for the test runs that report through the Datadog Agent.

This PR updates the setup guides to:

- Group `DD_CIVISIBILITY_AGENTLESS_ENABLED`, `DD_API_KEY`, and `DD_SITE` as the required Agentless settings.
- Mark `DD_TRACE_AGENT_URL` as applicable only when using the Datadog Agent.
- Present `DD_TEST_SESSION_NAME` as an explicit optional environment variable in each updated guide.
- Move JavaScript session-name guidance from the `test_session.name` configuration entry into the environment variables section.
- Consolidate the common Java environment variables outside the build-tool-specific tabs.

### Merge readiness

- [x] Ready for merge

### AI assistance

Used Codex to audit the language setup guides, draft the documentation updates, and prepare the PR description. The author directed and reviewed the changes.
