### PR TITLE
[DOCS-15616] Add instructions for configuring Kubernetes clusters with Fleet Automation

### DIFF
--- a/hugo/content/en/agent/fleet_automation/configure_agents.md
+++ b/hugo/content/en/agent/fleet_automation/configure_agents.md
@@ -11,23 +11,26 @@ further_reading:
 site_support_id: fleet-automation-standard-features
 ---
 
-Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes through guided workflows in the UI or with custom YAML files.
+Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes through guided workflows in the UI or with custom YAML files. You can configure:
 
-## Prerequisites
+* [Agents running on hosts](#configure-host-based-agents)
+* (In Preview) [Agents running in Kubernetes clusters managed by the Datadog Operator](#configure-the-agent-on-kubernetes)
+
+You can also apply configuration updates [through the Fleet Automation API](#configure-agents-with-the-api).
+
+## Configure host-based Agents
+
+### Prerequisites
 
 - [Remote Configuration][9] enabled for your organization
 - Agent version 7.73+ for Agent and OTel Collector configuration (version 7.76+ for configuring integrations and secrets). To upgrade your Agents, see [Upgrade Agents][10].
 - Linux VMs installed with the install script or Ansible Datadog Role, or Windows VMs
 
-{{< callout url="https://www.datadoghq.com/product-preview/configure-agent-kubernetes-operator/" header="Join the Preview!" >}}
-Remote configuration of Agents in containerized workloads is in Preview. If you're interested in this feature, complete the form to request access.
-{{< /callout >}}
-
 {{< callout url="https://www.datadoghq.com/product-preview/modify-tags-fleet-automation/" header="Join the Preview!" >}}
 Managing Datadog Agent tags with Fleet Automation is in Preview. If you're interested in this feature, complete the form to request access.
 {{< /callout >}}
 
-## Configure multiple Agents
+### Configure multiple Agents
 
 1. In Fleet Automation, open the [Configuration][1] tab and click {{< ui >}}Configure Agents{{< /ui >}}.
 1. Scope the configuration to the target Agents. Filter by host information or tags to target a specific group.
@@ -41,7 +44,7 @@ Managing Datadog Agent tags with Fleet Automation is in Preview. If you're inter
 1. Review the deployment plan to confirm scoped Agents and deployment settings, such as rollout concurrency.
 1. Click {{< ui >}}Deploy Configuration{{< /ui >}} to start the deployment and track its progress from the [Deployments page][2].
 
-## Edit the configuration of a single Agent
+### Edit the configuration of a single Agent
 
 1. Navigate to [Fleet View][3]. 
 
@@ -58,6 +61,33 @@ Managing Datadog Agent tags with Fleet Automation is in Preview. If you're inter
 The example below shows the `logs_enabled` field changed from `false` to `true`, which enables log collection on the Agent after deployment.
 
 {{< img src="/agent/fleet_automation/agent_remote_management_single_agent_config2.png" alt="Edit and deploy Agent configuration changes." style="width:90%;" >}}
+
+## Configure the Agent on Kubernetes
+
+{{< callout url="https://www.datadoghq.com/product-preview/configure-agent-kubernetes-operator/" header="Join the Preview!" >}}
+Configuring Kubernetes Agents with the Datadog Operator in Fleet Automation is in Preview. If you're interested in this feature, complete the form to request access.
+{{< /callout >}}
+
+Use Fleet Automation to edit the `DatadogAgent` custom resource for an Operator-managed Kubernetes cluster. For example, you can enable or adjust APM, log collection, and process monitoring without applying an updated manifest to the cluster manually.
+
+### Prerequisites
+
+- The Datadog Agent is running in the Kubernetes cluster.
+- Datadog Operator v1.27 or later manages the Agent deployment.
+- Remote Configuration is enabled for the API key used by the Agent.
+- The Operator is configured to accept remote updates. For the required Operator settings, API and application keys, and cluster name requirements, see [Prerequisites for Kubernetes view][11].
+
+### Edit the cluster configuration
+
+1. Navigate to [Fleet View][3].
+1. Under {{< ui >}}View by infra type{{< /ui >}}, switch to the Kubernetes view.
+1. Select the cluster that you want to configure, then open the {{< ui >}}Configuration{{< /ui >}} tab.
+1. Click {{< ui >}}Edit{{< /ui >}} and update the `DatadogAgent` configuration.
+1. Review the changes, then click {{< ui >}}Deploy Changes{{< /ui >}}.
+
+Fleet Automation initiates the change, and Remote Configuration transmits it to the cluster. The Datadog Operator updates the `DatadogAgent` resource and rolls out the configuration across the Agent pods. If the rollout does not complete successfully, the Operator automatically restores the previous configuration.
+
+**Note**: Fleet Automation does not support editing Helm Chart values.
 
 ## Configure Agents with the API
 
@@ -102,3 +132,4 @@ For instructions on using mirrored or air-gapped repositories, see:
 [8]: /agent/guide/installing-the-agent-on-a-server-with-limited-internet-connectivity/
 [9]: /agent/guide/setup_remote_config
 [10]: /agent/fleet_automation/upgrade_agents/
+[11]: /agent/fleet_automation/fleet_view/#prerequisites-for-kubernetes-view

--- a/hugo/content/en/agent/fleet_automation/configure_agents.md
+++ b/hugo/content/en/agent/fleet_automation/configure_agents.md
@@ -11,12 +11,10 @@ further_reading:
 site_support_id: fleet-automation-standard-features
 ---
 
-Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes through guided workflows in the UI or with custom YAML files. You can configure:
+Use [Fleet Automation][3] to roll out and manage Datadog Agent configuration at scale. Apply configuration changes in the UI through guided workflows or with custom YAML files. You can also apply configuration updates [through the Fleet Automation API](#configure-agents-with-the-api). You can configure:
 
 * [Agents running on hosts](#configure-host-based-agents)
 * (In Preview) [Agents running in Kubernetes clusters managed by the Datadog Operator](#configure-the-agent-on-kubernetes)
-
-You can also apply configuration updates [through the Fleet Automation API](#configure-agents-with-the-api).
 
 ## Configure host-based Agents
 

--- a/hugo/content/en/agent/fleet_automation/fleet_view.md
+++ b/hugo/content/en/agent/fleet_automation/fleet_view.md
@@ -121,7 +121,7 @@ Most Kubernetes view features are available without version requirements. Specif
 |---|---|
 | View `DatadogAgent` configuration | Datadog Operator v1.24 or later |
 | View Helm Chart values | Datadog Helm Chart v3.157.0 or later |
-| Edit configuration | [Remote Configuration][6] enabled and Datadog Operator v1.27 or later |
+| Edit configuration (Preview) | [Remote Configuration][6] enabled and Datadog Operator v1.27 or later |
 | Edit configuration without setting a cluster name | Datadog Operator v1.30.0 or later |
 | View integrations on a Cluster Agent | Agent v7.72.0 or later |
 | View integration status on a Cluster Agent | Agent v7.79.0 or later |
@@ -159,7 +159,7 @@ Click a cluster to view:
 
 On the {{< ui >}}Configuration{{< /ui >}} tab, you can view configuration:
 
-- **Datadog Operator v1.24 or later**: View the `DatadogAgent` custom resource configuration. With Datadog Operator v1.27 or later, you can also edit the configuration from this tab.
+- **Datadog Operator v1.24 or later**: View the `DatadogAgent` custom resource configuration. With Datadog Operator v1.27 or later, you can also edit the configuration from this tab. Editing is in Preview. For instructions, see [Configure the Agent on Kubernetes][8].
 - **Datadog Helm Chart v3.157.0 or later**: View the Helm Chart values (`values.yaml`).
 
 ### Limitations
@@ -181,3 +181,4 @@ Compared to the default view, the Kubernetes view has the following limitations:
 [5]: /containers/datadog_operator
 [6]: /agent/guide/setup_remote_config
 [7]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+[8]: /agent/fleet_automation/configure_agents/#configure-the-agent-on-kubernetes


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds an explicit section + instructions for using Fleet Automation to configure your Kubernetes clusters. The feature has been in Preview for a while and there were brief mentions of it in the FA docs, but this makes it its own, linkable section under [Configure Agents](https://docs.datadoghq.com/agent/fleet_automation/configure_agents/).

I broke up that page into host-based vs. Kubernetes, so some of the existing headings were demoted. I also added a bulleted list to the page into to make the division clear.

### Merge readiness

- [ ] Ready for merge - waiting on approval from Ethan or FA engineer

### AI assistance

Used Codex to create the new structure and pull in prerequisites and other info from the ticket. Reviewed myself, adjusted the language, added the intro changes. Had Claude review, which flagged that the two Preview callouts on the page use slightly different language. PR description by me.

### Additional notes
