### PR TITLE
[DOCS-15562] Fix reference-link collision breaking Android tracing SDK links

### DIFF
--- a/hugo/content/en/tracing/trace_collection/dd_libraries/android.md
+++ b/hugo/content/en/tracing/trace_collection/dd_libraries/android.md
@@ -1075,9 +1075,9 @@ The following methods in `DatadogTracerBuilder` can be used when initializing th
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/visualization/#trace
+[1]: /glossary/#trace
 [2]: https://github.com/DataDog/dd-sdk-android/tree/develop/features/dd-sdk-android-trace
-[3]: /tracing/visualization/#spans
+[3]: /glossary/#span
 [4]: /account_management/api-app-keys/#client-tokens
 [5]: /account_management/api-app-keys/#api-keys
 [6]: https://square.github.io/okhttp/interceptors/

--- a/hugo/layouts/shortcodes/android-otel-note.en.md
+++ b/hugo/layouts/shortcodes/android-otel-note.en.md
@@ -1,9 +1,9 @@
-The Datadog Tracer implements the [OpenTelemetry][otel-spec] standard, and Datadog recommends using it as an interface for tracing your application because it's vendor-neutral, supports many languages and frameworks, and unifies traces, metrics, and logs under one standard. See instructions on [setting up OpenTelemetry integration with the SDK][otel-setup]. 
+The Datadog Tracer implements the [OpenTelemetry][101] standard, and Datadog recommends using it as an interface for tracing your application because it's vendor-neutral, supports many languages and frameworks, and unifies traces, metrics, and logs under one standard. See instructions on [setting up OpenTelemetry integration with the SDK][103]. 
 
-**Note:** The OpenTelemetry specification library requires [desugaring][otel-desugaring] to be enabled for projects with a `minSdk` < `26`. If you cannot enable desugaring in your project, you can still use the Trace product with the Datadog API instead.
+**Note:** The OpenTelemetry specification library requires [desugaring][102] to be enabled for projects with a `minSdk` < `26`. If you cannot enable desugaring in your project, you can still use the Trace product with the Datadog API instead.
 
 **Note**: The *Datadog API* implementation helps you transition from OpenTracing to OpenTelemetry.
 
-[otel-spec]: /tracing/trace_collection/custom_instrumentation/android/otel
-[otel-desugaring]: https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#requirements
-[otel-setup]: /tracing/trace_collection/custom_instrumentation/android/otel/?tab=kotlin
+[101]: /tracing/trace_collection/custom_instrumentation/android/otel
+[102]: https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#requirements
+[103]: /tracing/trace_collection/custom_instrumentation/android/otel/?tab=kotlin

--- a/hugo/layouts/shortcodes/android-otel-note.en.md
+++ b/hugo/layouts/shortcodes/android-otel-note.en.md
@@ -1,9 +1,9 @@
-The Datadog Tracer implements the [OpenTelemetry][1] standard, and Datadog recommends using it as an interface for tracing your application because it's vendor-neutral, supports many languages and frameworks, and unifies traces, metrics, and logs under one standard. See instructions on [setting up OpenTelemetry integration with the SDK][3]. 
+The Datadog Tracer implements the [OpenTelemetry][otel-spec] standard, and Datadog recommends using it as an interface for tracing your application because it's vendor-neutral, supports many languages and frameworks, and unifies traces, metrics, and logs under one standard. See instructions on [setting up OpenTelemetry integration with the SDK][otel-setup]. 
 
-**Note:** The OpenTelemetry specification library requires [desugaring][2] to be enabled for projects with a `minSdk` < `26`. If you cannot enable desugaring in your project, you can still use the Trace product with the Datadog API instead.
+**Note:** The OpenTelemetry specification library requires [desugaring][otel-desugaring] to be enabled for projects with a `minSdk` < `26`. If you cannot enable desugaring in your project, you can still use the Trace product with the Datadog API instead.
 
 **Note**: The *Datadog API* implementation helps you transition from OpenTracing to OpenTelemetry.
 
-[1]: /tracing/trace_collection/custom_instrumentation/android/otel
-[2]: https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#requirements
-[3]: /tracing/trace_collection/custom_instrumentation/android/otel/?tab=kotlin
+[otel-spec]: /tracing/trace_collection/custom_instrumentation/android/otel
+[otel-desugaring]: https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#requirements
+[otel-setup]: /tracing/trace_collection/custom_instrumentation/android/otel/?tab=kotlin


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
The `android-otel-note` shortcode used numeric reference labels that conflicted with pages defining their own, and 2 of its links were outdated.

This PR:
- Renames the shortcode's reference numbers so pages that references no longer conflict.
- Updates 2 outdated links to the correct glossary terms.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to identify the root cause, apply the fix, and verify no new collisions were introduced across the shortcode's five consuming pages.

### Additional notes