### PR TITLE
astro Docs: [WEB-10078] Fix content discrepancies between Astro and Hugo

### DIFF
--- a/astro/README.md
+++ b/astro/README.md
@@ -11,6 +11,7 @@ This is the next-generation Datadog documentation site, built with Astro 7, Mark
 ## Getting started
 
 ```bash
+yarn --cwd shared/packages/ask-ai install
 cd astro
 yarn install
 yarn dev

--- a/astro/src/components/ApiSchemaTable/SchemaFieldRow.astro
+++ b/astro/src/components/ApiSchemaTable/SchemaFieldRow.astro
@@ -47,12 +47,18 @@ const displayType =
 const optionFields: SchemaField[] =
   field.unionOptions?.map((option) => ({
     name: option.label,
-    type: "object",
+    // The branch's own type, so a scalar variant reads `double` rather than
+    // `object`. Scalar variants carry no nested rows.
+    type: option.type,
     required: false,
     deprecated: false,
     readOnly: false,
     description: option.description ?? "",
-    children: option.fields,
+    ...(option.enumValues ? { enumValues: option.enumValues } : {}),
+    ...(option.defaultValue !== undefined
+      ? { defaultValue: option.defaultValue }
+      : {}),
+    ...(option.fields.length > 0 ? { children: option.fields } : {}),
   })) ?? [];
 ---
 

--- a/astro/src/components/ApiSchemaTable/plaintext/ApiSchemaTable.ts
+++ b/astro/src/components/ApiSchemaTable/plaintext/ApiSchemaTable.ts
@@ -62,7 +62,8 @@ function schemaFieldsToTableRows(
         rows.push({
           parent: field.name || UNNAMED_FIELD_LABEL,
           field: opt.label,
-          type: "object",
+          // The branch's own type: a scalar variant reads `double`, not `object`.
+          type: getFieldType({ type: opt.type } as SchemaField),
           description: opt.description ?? "",
         });
         rows.push(...schemaFieldsToTableRows(opt.fields, opt.label));

--- a/astro/src/components/ApiSchemaTable/plaintext/tests/unit.test.ts
+++ b/astro/src/components/ApiSchemaTable/plaintext/tests/unit.test.ts
@@ -83,6 +83,7 @@ describe("apiSchemaTableNode", () => {
         unionOptions: [
           {
             label: "AWSIntegration",
+            type: "object",
             fields: [
               field({
                 name: "aws_account_id",

--- a/astro/src/components/ApiSchemaTable/tests/ApiSchemaTable.unit.test.ts
+++ b/astro/src/components/ApiSchemaTable/tests/ApiSchemaTable.unit.test.ts
@@ -69,6 +69,7 @@ describe("ApiSchemaTable type column", () => {
       unionOptions: [
         {
           label: "<type=web>",
+          type: "object",
           fields: [
             {
               name: "password",
@@ -142,6 +143,7 @@ describe("ApiSchemaTable expand-all toolbar", () => {
         unionOptions: [
           {
             label: "Option A",
+            type: "object",
             fields: [
               {
                 name: "value",
@@ -274,6 +276,7 @@ describe("ApiSchemaTable — modifiers and content", () => {
         unionOptions: [
           {
             label: "Option A",
+            type: "object",
             fields: [
               {
                 name: "value",

--- a/astro/src/lib/api/__snapshots__/getOperationView/aws-integration.list-all-aws-integrations.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/aws-integration.list-all-aws-integrations.json
@@ -74,6 +74,7 @@
                       "unionOptions": [
                         {
                           "label": "Object 1",
+                          "type": "object",
                           "description": "AWS Authentication config to integrate your account using an access key pair.",
                           "fields": [
                             {
@@ -96,6 +97,7 @@
                         },
                         {
                           "label": "Object 2",
+                          "type": "object",
                           "description": "AWS Authentication config to integrate your account using an IAM role.",
                           "fields": [
                             {
@@ -128,7 +130,7 @@
                     },
                     {
                       "name": "aws_partition",
-                      "type": "string",
+                      "type": "enum",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -149,6 +151,7 @@
                       "unionOptions": [
                         {
                           "label": "Object 1",
+                          "type": "object",
                           "description": "Include all regions. Defaults to `true`.",
                           "fields": [
                             {
@@ -163,6 +166,7 @@
                         },
                         {
                           "label": "Object 2",
+                          "type": "object",
                           "description": "Include only these regions.",
                           "fields": [
                             {
@@ -179,7 +183,7 @@
                     },
                     {
                       "name": "created_at",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -307,6 +311,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "Exclude only these namespaces from metrics collection.\nDefaults to `[\"AWS/SQS\", \"AWS/ElasticMapReduce\", \"AWS/Usage\"]`.\n`AWS/SQS`, `AWS/ElasticMapReduce`, and `AWS/Usage` are excluded by default\nto reduce your AWS CloudWatch costs from `GetMetricData` API calls.",
                               "fields": [
                                 {
@@ -321,6 +326,7 @@
                             },
                             {
                               "label": "Object 2",
+                              "type": "object",
                               "description": "Include only these namespaces.",
                               "fields": [
                                 {
@@ -365,7 +371,7 @@
                     },
                     {
                       "name": "modified_at",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -415,6 +421,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "Include all services.",
                               "fields": [
                                 {
@@ -429,6 +436,7 @@
                             },
                             {
                               "label": "Object 2",
+                              "type": "object",
                               "description": "Include only these services. Defaults to `[]`.",
                               "fields": [
                                 {
@@ -457,7 +465,7 @@
                 },
                 {
                   "name": "type",
-                  "type": "string",
+                  "type": "enum",
                   "required": true,
                   "deprecated": false,
                   "readOnly": false,

--- a/astro/src/lib/api/__snapshots__/getOperationView/dashboard-lists.get-all-dashboard-lists.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/dashboard-lists.get-all-dashboard-lists.json
@@ -77,7 +77,7 @@
                 },
                 {
                   "name": "created",
-                  "type": "string (date-time)",
+                  "type": "date-time",
                   "required": false,
                   "deprecated": false,
                   "readOnly": true,
@@ -85,7 +85,7 @@
                 },
                 {
                   "name": "dashboard_count",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": true,
@@ -93,7 +93,7 @@
                 },
                 {
                   "name": "id",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": true,
@@ -109,7 +109,7 @@
                 },
                 {
                   "name": "modified",
-                  "type": "string (date-time)",
+                  "type": "date-time",
                   "required": false,
                   "deprecated": false,
                   "readOnly": true,

--- a/astro/src/lib/api/__snapshots__/getOperationView/dashboards.get-a-dashboard.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/dashboards.get-a-dashboard.json
@@ -61,7 +61,7 @@
             },
             {
               "name": "created_at",
-              "type": "string (date-time)",
+              "type": "date-time",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -93,7 +93,7 @@
             },
             {
               "name": "layout_type",
-              "type": "string",
+              "type": "enum",
               "required": true,
               "deprecated": false,
               "readOnly": false,
@@ -105,7 +105,7 @@
             },
             {
               "name": "modified_at",
-              "type": "string (date-time)",
+              "type": "date-time",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -121,7 +121,7 @@
             },
             {
               "name": "reflow_type",
-              "type": "string",
+              "type": "enum",
               "required": false,
               "deprecated": false,
               "readOnly": false,
@@ -149,7 +149,7 @@
               "children": [
                 {
                   "name": "id",
-                  "type": "string (uuid)",
+                  "type": "uuid",
                   "required": true,
                   "deprecated": false,
                   "readOnly": false,
@@ -325,6 +325,7 @@
                   "unionOptions": [
                     {
                       "label": "<type=alert_value>",
+                      "type": "object",
                       "description": "Alert values are query values showing the current value of the metric in any monitor defined on your system.",
                       "fields": [
                         {
@@ -345,7 +346,7 @@
                         },
                         {
                           "name": "precision",
-                          "type": "integer (int64)",
+                          "type": "int64",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -353,7 +354,7 @@
                         },
                         {
                           "name": "text_align",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -374,7 +375,7 @@
                         },
                         {
                           "name": "title_align",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -395,7 +396,7 @@
                         },
                         {
                           "name": "type",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -417,6 +418,7 @@
                     },
                     {
                       "label": "<type=timeseries>",
+                      "type": "object",
                       "description": "The timeseries visualization allows you to display the evolution of one or more metrics, log events, or Indexed Spans over time.",
                       "fields": [
                         {
@@ -505,7 +507,7 @@
                         },
                         {
                           "name": "legend_layout",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -608,7 +610,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -634,7 +636,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -666,7 +668,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -714,7 +716,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -776,7 +778,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -802,7 +804,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -834,7 +836,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -882,7 +884,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -912,7 +914,7 @@
                             },
                             {
                               "name": "display_type",
-                              "type": "string",
+                              "type": "enum",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -958,7 +960,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -984,7 +986,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1016,7 +1018,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -1064,7 +1066,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1110,7 +1112,7 @@
                                 },
                                 {
                                   "name": "cell_display_mode",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -1131,7 +1133,7 @@
                                   "children": [
                                     {
                                       "name": "trend_type",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1144,7 +1146,7 @@
                                     },
                                     {
                                       "name": "y_scale",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1166,7 +1168,7 @@
                                   "children": [
                                     {
                                       "name": "comparator",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1221,7 +1223,7 @@
                                     },
                                     {
                                       "name": "palette",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1258,7 +1260,7 @@
                                     },
                                     {
                                       "name": "value",
-                                      "type": "number (double)",
+                                      "type": "double",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1284,7 +1286,7 @@
                                   "children": [
                                     {
                                       "name": "count",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1292,7 +1294,7 @@
                                     },
                                     {
                                       "name": "order",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1323,6 +1325,7 @@
                                       "unionOptions": [
                                         {
                                           "label": "<type=canonical_unit>",
+                                          "type": "object",
                                           "description": "Canonical unit.",
                                           "fields": [
                                             {
@@ -1335,7 +1338,7 @@
                                             },
                                             {
                                               "name": "type",
-                                              "type": "string",
+                                              "type": "enum",
                                               "required": false,
                                               "deprecated": false,
                                               "readOnly": false,
@@ -1356,6 +1359,7 @@
                                         },
                                         {
                                           "label": "<type=custom_unit_label>",
+                                          "type": "object",
                                           "description": "Custom unit.",
                                           "fields": [
                                             {
@@ -1368,7 +1372,7 @@
                                             },
                                             {
                                               "name": "type",
-                                              "type": "string",
+                                              "type": "enum",
                                               "required": false,
                                               "deprecated": false,
                                               "readOnly": false,
@@ -1391,7 +1395,7 @@
                                       "children": [
                                         {
                                           "name": "type",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -1430,7 +1434,7 @@
                                     },
                                     {
                                       "name": "palette_index",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1474,7 +1478,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1500,7 +1504,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1532,7 +1536,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -1580,7 +1584,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1668,7 +1672,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1694,7 +1698,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1726,7 +1730,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -1774,7 +1778,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1828,7 +1832,7 @@
                                 },
                                 {
                                   "name": "limit",
-                                  "type": "integer (int64)",
+                                  "type": "int64",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -1886,7 +1890,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1912,7 +1916,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -1944,7 +1948,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -1992,7 +1996,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2038,11 +2042,12 @@
                               "unionOptions": [
                                 {
                                   "label": "<data_source=metrics>",
+                                  "type": "object",
                                   "description": "A formula and functions metrics query.",
                                   "fields": [
                                     {
                                       "name": "aggregator",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2068,7 +2073,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2095,7 +2100,7 @@
                                     },
                                     {
                                       "name": "semantic_mode",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2109,6 +2114,7 @@
                                 },
                                 {
                                   "label": "Object 2",
+                                  "type": "object",
                                   "description": "A formula and functions events query.",
                                   "fields": [
                                     {
@@ -2121,7 +2127,7 @@
                                       "children": [
                                         {
                                           "name": "aggregation",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -2143,7 +2149,7 @@
                                         },
                                         {
                                           "name": "interval",
-                                          "type": "integer (int64)",
+                                          "type": "int64",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -2169,7 +2175,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2200,6 +2206,7 @@
                                       "unionOptions": [
                                         {
                                           "label": "Object 1",
+                                          "type": "[object]",
                                           "description": "List of objects used to group by.",
                                           "fields": [
                                             {
@@ -2220,7 +2227,7 @@
                                                 },
                                                 {
                                                   "name": "limit",
-                                                  "type": "integer (int64)",
+                                                  "type": "int64",
                                                   "required": false,
                                                   "deprecated": false,
                                                   "readOnly": false,
@@ -2240,6 +2247,7 @@
                                         },
                                         {
                                           "label": "Object 2",
+                                          "type": "object",
                                           "description": "Flat group by configuration using multiple event facet fields.",
                                           "fields": [
                                             {
@@ -2252,7 +2260,7 @@
                                             },
                                             {
                                               "name": "limit",
-                                              "type": "integer (int64)",
+                                              "type": "int64",
                                               "required": false,
                                               "deprecated": false,
                                               "readOnly": false,
@@ -2268,7 +2276,7 @@
                                               "children": [
                                                 {
                                                   "name": "aggregation",
-                                                  "type": "string",
+                                                  "type": "enum",
                                                   "required": true,
                                                   "deprecated": false,
                                                   "readOnly": false,
@@ -2298,7 +2306,7 @@
                                                 },
                                                 {
                                                   "name": "order",
-                                                  "type": "string",
+                                                  "type": "enum",
                                                   "required": false,
                                                   "deprecated": false,
                                                   "readOnly": false,
@@ -2361,11 +2369,12 @@
                                 },
                                 {
                                   "label": "Object 3",
+                                  "type": "object",
                                   "description": "Process query using formulas and functions.",
                                   "fields": [
                                     {
                                       "name": "aggregator",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2391,7 +2400,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2411,7 +2420,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2435,7 +2444,7 @@
                                     },
                                     {
                                       "name": "sort",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2466,6 +2475,7 @@
                                 },
                                 {
                                   "label": "<data_source=apm_dependency_stats>",
+                                  "type": "object",
                                   "description": "A formula and functions APM dependency stats query.",
                                   "fields": [
                                     {
@@ -2478,7 +2488,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2553,7 +2563,7 @@
                                     },
                                     {
                                       "name": "stat",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2572,6 +2582,7 @@
                                 },
                                 {
                                   "label": "<data_source=apm_resource_stats>",
+                                  "type": "object",
                                   "description": "APM resource stats query using formulas and functions.",
                                   "fields": [
                                     {
@@ -2584,7 +2595,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2659,7 +2670,7 @@
                                     },
                                     {
                                       "name": "stat",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2682,11 +2693,12 @@
                                 },
                                 {
                                   "label": "<data_source=apm_metrics>",
+                                  "type": "object",
                                   "description": "A formula and functions APM metrics query.",
                                   "fields": [
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2769,7 +2781,7 @@
                                     },
                                     {
                                       "name": "span_kind",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2784,7 +2796,7 @@
                                     },
                                     {
                                       "name": "stat",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2812,6 +2824,7 @@
                                 },
                                 {
                                   "label": "<data_source=slo>",
+                                  "type": "object",
                                   "description": "A formula and functions metrics query.",
                                   "fields": [
                                     {
@@ -2832,7 +2845,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2843,7 +2856,7 @@
                                     },
                                     {
                                       "name": "group_mode",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2855,7 +2868,7 @@
                                     },
                                     {
                                       "name": "measure",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2889,7 +2902,7 @@
                                     },
                                     {
                                       "name": "slo_query_type",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2904,11 +2917,12 @@
                                 },
                                 {
                                   "label": "<data_source=cloud_cost>",
+                                  "type": "object",
                                   "description": "A formula and functions Cloud Cost query.",
                                   "fields": [
                                     {
                                       "name": "aggregator",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2932,7 +2946,7 @@
                                     },
                                     {
                                       "name": "data_source",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -2963,7 +2977,7 @@
                             },
                             {
                               "name": "response_format",
-                              "type": "string",
+                              "type": "enum",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -3008,7 +3022,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3034,7 +3048,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3066,7 +3080,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -3114,7 +3128,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3176,7 +3190,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3202,7 +3216,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3234,7 +3248,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -3282,7 +3296,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3328,7 +3342,7 @@
                                 },
                                 {
                                   "name": "line_type",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3341,7 +3355,7 @@
                                 },
                                 {
                                   "name": "line_width",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3354,7 +3368,7 @@
                                 },
                                 {
                                   "name": "order_by",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3447,6 +3461,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "Wrapper for live span",
                               "fields": [
                                 {
@@ -3459,7 +3474,7 @@
                                 },
                                 {
                                   "name": "live_span",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3488,6 +3503,7 @@
                             },
                             {
                               "label": "<type=live>",
+                              "type": "object",
                               "description": "Used for arbitrary live span times, such as 17 minutes or 6 hours.",
                               "fields": [
                                 {
@@ -3500,7 +3516,7 @@
                                 },
                                 {
                                   "name": "type",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3511,7 +3527,7 @@
                                 },
                                 {
                                   "name": "unit",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3527,7 +3543,7 @@
                                 },
                                 {
                                   "name": "value",
-                                  "type": "integer (int64)",
+                                  "type": "int64",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3537,11 +3553,12 @@
                             },
                             {
                               "label": "<type=fixed>",
+                              "type": "object",
                               "description": "Used for fixed span times, such as 'March 1 to March 7'.",
                               "fields": [
                                 {
                                   "name": "from",
-                                  "type": "integer (int64)",
+                                  "type": "int64",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3557,7 +3574,7 @@
                                 },
                                 {
                                   "name": "to",
-                                  "type": "integer (int64)",
+                                  "type": "int64",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3565,7 +3582,7 @@
                                 },
                                 {
                                   "name": "type",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3588,7 +3605,7 @@
                         },
                         {
                           "name": "title_align",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -3609,7 +3626,7 @@
                         },
                         {
                           "name": "type",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3676,6 +3693,7 @@
                     },
                     {
                       "label": "<type=group>",
+                      "type": "object",
                       "description": "The group widget allows you to keep similar graphs together on your dashboard. Each group has a custom header, can hold one to many graphs, and is collapsible.",
                       "fields": [
                         {
@@ -3696,7 +3714,7 @@
                         },
                         {
                           "name": "layout_type",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3724,7 +3742,7 @@
                         },
                         {
                           "name": "title_align",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -3737,7 +3755,7 @@
                         },
                         {
                           "name": "type",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3771,7 +3789,7 @@
                 },
                 {
                   "name": "id",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3787,7 +3805,7 @@
                   "children": [
                     {
                       "name": "height",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": true,
                       "deprecated": false,
                       "readOnly": false,
@@ -3803,7 +3821,7 @@
                     },
                     {
                       "name": "width",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": true,
                       "deprecated": false,
                       "readOnly": false,
@@ -3811,7 +3829,7 @@
                     },
                     {
                       "name": "x",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": true,
                       "deprecated": false,
                       "readOnly": false,
@@ -3819,7 +3837,7 @@
                     },
                     {
                       "name": "y",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": true,
                       "deprecated": false,
                       "readOnly": false,

--- a/astro/src/lib/api/__snapshots__/getOperationView/incidents.create-an-incident.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/incidents.create-an-incident.json
@@ -91,11 +91,12 @@
                     "unionOptions": [
                       {
                         "label": "<cell_type=markdown>",
+                        "type": "object",
                         "description": "Timeline cell data for Markdown timeline cells for a create request.",
                         "fields": [
                           {
                             "name": "cell_type",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -214,7 +215,7 @@
                           },
                           {
                             "name": "type",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -232,7 +233,7 @@
               },
               {
                 "name": "type",
-                "type": "string",
+                "type": "enum",
                 "required": true,
                 "deprecated": false,
                 "readOnly": false,
@@ -275,7 +276,7 @@
                   "children": [
                     {
                       "name": "archived",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -283,7 +284,7 @@
                     },
                     {
                       "name": "case_id",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -291,7 +292,7 @@
                     },
                     {
                       "name": "created",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -299,7 +300,7 @@
                     },
                     {
                       "name": "customer_impact_duration",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -307,7 +308,7 @@
                     },
                     {
                       "name": "customer_impact_end",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -323,7 +324,7 @@
                     },
                     {
                       "name": "customer_impact_start",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -339,7 +340,7 @@
                     },
                     {
                       "name": "declared",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -381,7 +382,7 @@
                     },
                     {
                       "name": "detected",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -413,7 +414,7 @@
                     },
                     {
                       "name": "modified",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -473,7 +474,7 @@
                     },
                     {
                       "name": "public_id",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -481,7 +482,7 @@
                     },
                     {
                       "name": "resolved",
-                      "type": "string (date-time)",
+                      "type": "date-time",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -489,7 +490,7 @@
                     },
                     {
                       "name": "severity",
-                      "type": "string",
+                      "type": "enum",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -514,7 +515,7 @@
                     },
                     {
                       "name": "time_to_detect",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -522,7 +523,7 @@
                     },
                     {
                       "name": "time_to_internal_response",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -530,7 +531,7 @@
                     },
                     {
                       "name": "time_to_repair",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -538,7 +539,7 @@
                     },
                     {
                       "name": "time_to_resolve",
-                      "type": "integer (int64)",
+                      "type": "int64",
                       "required": false,
                       "deprecated": false,
                       "readOnly": true,
@@ -604,7 +605,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -644,7 +645,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -684,7 +685,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -724,7 +725,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -764,7 +765,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -803,7 +804,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -843,7 +844,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -883,7 +884,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -922,7 +923,7 @@
                             },
                             {
                               "name": "type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -939,7 +940,7 @@
                 },
                 {
                   "name": "type",
-                  "type": "string",
+                  "type": "enum",
                   "required": true,
                   "deprecated": false,
                   "readOnly": false,
@@ -961,6 +962,7 @@
               "unionOptions": [
                 {
                   "label": "<type=users>",
+                  "type": "object",
                   "description": "User object returned by the API.",
                   "fields": [
                     {
@@ -1023,7 +1025,7 @@
                     },
                     {
                       "name": "type",
-                      "type": "string",
+                      "type": "enum",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -1037,6 +1039,7 @@
                 },
                 {
                   "label": "<type=incident_attachments>",
+                  "type": "object",
                   "description": "Attachment data from a response.",
                   "fields": [
                     {
@@ -1075,7 +1078,7 @@
                         },
                         {
                           "name": "attachment_type",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -1087,7 +1090,7 @@
                         },
                         {
                           "name": "modified",
-                          "type": "string (date-time)",
+                          "type": "date-time",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -1137,7 +1140,7 @@
                                 },
                                 {
                                   "name": "type",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -1177,7 +1180,7 @@
                                 },
                                 {
                                   "name": "type",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -1195,7 +1198,7 @@
                     },
                     {
                       "name": "type",
-                      "type": "string",
+                      "type": "enum",
                       "required": true,
                       "deprecated": false,
                       "readOnly": false,

--- a/astro/src/lib/api/__snapshots__/getOperationView/monitors.create-a-monitor.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/monitors.create-a-monitor.json
@@ -42,7 +42,7 @@
             "children": [
               {
                 "name": "category",
-                "type": "string",
+                "type": "enum",
                 "required": true,
                 "deprecated": false,
                 "readOnly": false,
@@ -69,7 +69,7 @@
               },
               {
                 "name": "resource_type",
-                "type": "string",
+                "type": "enum",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -89,58 +89,8 @@
             ]
           },
           {
-            "name": "created",
-            "type": "string (date-time)",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Timestamp of the monitor creation."
-          },
-          {
-            "name": "creator",
-            "type": "object",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Object describing the creator of the shared element.",
-            "children": [
-              {
-                "name": "email",
-                "type": "string",
-                "required": false,
-                "deprecated": false,
-                "readOnly": false,
-                "description": "Email of the creator."
-              },
-              {
-                "name": "handle",
-                "type": "string",
-                "required": false,
-                "deprecated": false,
-                "readOnly": false,
-                "description": "Handle of the creator."
-              },
-              {
-                "name": "name",
-                "type": "string",
-                "required": false,
-                "deprecated": false,
-                "readOnly": false,
-                "description": "Name of the creator."
-              }
-            ]
-          },
-          {
-            "name": "deleted",
-            "type": "string (date-time)",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Whether or not the monitor is deleted. (Always `null`)"
-          },
-          {
             "name": "draft_status",
-            "type": "string",
+            "type": "enum",
             "required": false,
             "deprecated": false,
             "readOnly": false,
@@ -152,14 +102,6 @@
             "defaultValue": "published"
           },
           {
-            "name": "id",
-            "type": "integer (int64)",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "ID of this monitor."
-          },
-          {
             "name": "matching_downtimes",
             "type": "[object]",
             "required": false,
@@ -169,19 +111,11 @@
             "children": [
               {
                 "name": "end",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
                 "description": "POSIX timestamp to end the downtime."
-              },
-              {
-                "name": "id",
-                "type": "integer (int64)",
-                "required": true,
-                "deprecated": false,
-                "readOnly": true,
-                "description": "The downtime ID."
               },
               {
                 "name": "scope",
@@ -193,7 +127,7 @@
               },
               {
                 "name": "start",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -208,22 +142,6 @@
             "deprecated": false,
             "readOnly": false,
             "description": "A message to include with notifications for this monitor."
-          },
-          {
-            "name": "modified",
-            "type": "string (date-time)",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Last timestamp when the monitor was edited."
-          },
-          {
-            "name": "multi",
-            "type": "boolean",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Whether or not the monitor is broken down on different groups."
           },
           {
             "name": "name",
@@ -241,48 +159,6 @@
             "readOnly": false,
             "description": "List of options associated with your monitor.",
             "children": [
-              {
-                "name": "aggregation",
-                "type": "object",
-                "required": false,
-                "deprecated": false,
-                "readOnly": true,
-                "description": "Type of aggregation performed in the monitor query.",
-                "children": [
-                  {
-                    "name": "group_by",
-                    "type": "string",
-                    "required": false,
-                    "deprecated": false,
-                    "readOnly": false,
-                    "description": "Group to break down the monitor on."
-                  },
-                  {
-                    "name": "metric",
-                    "type": "string",
-                    "required": false,
-                    "deprecated": false,
-                    "readOnly": false,
-                    "description": "Metric name used in the monitor."
-                  },
-                  {
-                    "name": "type",
-                    "type": "string",
-                    "required": false,
-                    "deprecated": false,
-                    "readOnly": false,
-                    "description": "Metric type used in the monitor."
-                  }
-                ]
-              },
-              {
-                "name": "device_ids",
-                "type": "[string]",
-                "required": false,
-                "deprecated": true,
-                "readOnly": true,
-                "description": "IDs of the device the Synthetics monitor is running on."
-              },
               {
                 "name": "enable_logs_sample",
                 "type": "boolean",
@@ -309,7 +185,7 @@
               },
               {
                 "name": "evaluation_delay",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -350,7 +226,7 @@
               },
               {
                 "name": "min_failure_duration",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -359,7 +235,7 @@
               },
               {
                 "name": "min_location_failed",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -368,7 +244,7 @@
               },
               {
                 "name": "new_group_delay",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -376,7 +252,7 @@
               },
               {
                 "name": "new_host_delay",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": true,
                 "readOnly": false,
@@ -385,7 +261,7 @@
               },
               {
                 "name": "no_data_timeframe",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -393,7 +269,7 @@
               },
               {
                 "name": "notification_preset_name",
-                "type": "string",
+                "type": "enum",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -436,7 +312,7 @@
               },
               {
                 "name": "on_missing_data",
-                "type": "string",
+                "type": "enum",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -450,7 +326,7 @@
               },
               {
                 "name": "renotify_interval",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -459,7 +335,7 @@
               },
               {
                 "name": "renotify_occurrences",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -551,7 +427,7 @@
                       },
                       {
                         "name": "hour_starts",
-                        "type": "integer (int32)",
+                        "type": "int32",
                         "required": false,
                         "deprecated": false,
                         "readOnly": false,
@@ -559,7 +435,7 @@
                       },
                       {
                         "name": "month_starts",
-                        "type": "integer (int32)",
+                        "type": "int32",
                         "required": false,
                         "deprecated": false,
                         "readOnly": false,
@@ -629,7 +505,7 @@
                 "children": [
                   {
                     "name": "critical",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -637,7 +513,7 @@
                   },
                   {
                     "name": "critical_recovery",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -645,7 +521,7 @@
                   },
                   {
                     "name": "ok",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -653,7 +529,7 @@
                   },
                   {
                     "name": "unknown",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -661,7 +537,7 @@
                   },
                   {
                     "name": "warning",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -669,7 +545,7 @@
                   },
                   {
                     "name": "warning_recovery",
-                    "type": "number (double)",
+                    "type": "double",
                     "required": false,
                     "deprecated": false,
                     "readOnly": false,
@@ -679,7 +555,7 @@
               },
               {
                 "name": "timeout_h",
-                "type": "integer (int64)",
+                "type": "int64",
                 "required": false,
                 "deprecated": false,
                 "readOnly": false,
@@ -696,6 +572,7 @@
                 "unionOptions": [
                   {
                     "label": "Object 1",
+                    "type": "object",
                     "description": "A formula and functions events query.",
                     "fields": [
                       {
@@ -708,7 +585,7 @@
                         "children": [
                           {
                             "name": "aggregation",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -730,7 +607,7 @@
                           },
                           {
                             "name": "interval",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -756,7 +633,7 @@
                       },
                       {
                         "name": "data_source",
-                        "type": "string",
+                        "type": "enum",
                         "required": true,
                         "deprecated": false,
                         "readOnly": false,
@@ -792,7 +669,7 @@
                           },
                           {
                             "name": "limit",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -808,7 +685,7 @@
                             "children": [
                               {
                                 "name": "aggregation",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -838,7 +715,7 @@
                               },
                               {
                                 "name": "order",
-                                "type": "string",
+                                "type": "enum",
                                 "required": false,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -891,11 +768,12 @@
                   },
                   {
                     "label": "Object 2",
+                    "type": "object",
                     "description": "A formula and functions cost query.",
                     "fields": [
                       {
                         "name": "aggregator",
-                        "type": "string",
+                        "type": "enum",
                         "required": false,
                         "deprecated": false,
                         "readOnly": false,
@@ -914,7 +792,7 @@
                       },
                       {
                         "name": "data_source",
-                        "type": "string",
+                        "type": "enum",
                         "required": true,
                         "deprecated": false,
                         "readOnly": false,
@@ -945,11 +823,12 @@
                   },
                   {
                     "label": "Object 3",
+                    "type": "object",
                     "description": "A formula and functions data quality query.",
                     "fields": [
                       {
                         "name": "data_source",
-                        "type": "string",
+                        "type": "enum",
                         "required": true,
                         "deprecated": false,
                         "readOnly": false,
@@ -1024,7 +903,7 @@
                           },
                           {
                             "name": "model_type_override",
-                            "type": "string",
+                            "type": "enum",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -1065,6 +944,7 @@
                   },
                   {
                     "label": "Object 4",
+                    "type": "object",
                     "description": "A formula and functions aggregate augmented query. Used to enrich base query results with data from a reference table.",
                     "fields": [
                       {
@@ -1077,6 +957,7 @@
                         "unionOptions": [
                           {
                             "label": "Object 1",
+                            "type": "object",
                             "description": "A formula and functions events query.",
                             "fields": [
                               {
@@ -1089,7 +970,7 @@
                                 "children": [
                                   {
                                     "name": "aggregation",
-                                    "type": "string",
+                                    "type": "enum",
                                     "required": true,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1111,7 +992,7 @@
                                   },
                                   {
                                     "name": "interval",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1137,7 +1018,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1173,7 +1054,7 @@
                                   },
                                   {
                                     "name": "limit",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1189,7 +1070,7 @@
                                     "children": [
                                       {
                                         "name": "aggregation",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": true,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -1219,7 +1100,7 @@
                                       },
                                       {
                                         "name": "order",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": false,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -1272,6 +1153,7 @@
                           },
                           {
                             "label": "<data_source=reference_table>",
+                            "type": "object",
                             "description": "A reference table query for use in aggregate queries.",
                             "fields": [
                               {
@@ -1302,7 +1184,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1349,6 +1231,7 @@
                         "unionOptions": [
                           {
                             "label": "Object 1",
+                            "type": "object",
                             "description": "A formula and functions events query.",
                             "fields": [
                               {
@@ -1361,7 +1244,7 @@
                                 "children": [
                                   {
                                     "name": "aggregation",
-                                    "type": "string",
+                                    "type": "enum",
                                     "required": true,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1383,7 +1266,7 @@
                                   },
                                   {
                                     "name": "interval",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1409,7 +1292,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1445,7 +1328,7 @@
                                   },
                                   {
                                     "name": "limit",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1461,7 +1344,7 @@
                                     "children": [
                                       {
                                         "name": "aggregation",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": true,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -1491,7 +1374,7 @@
                                       },
                                       {
                                         "name": "order",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": false,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -1544,11 +1427,12 @@
                           },
                           {
                             "label": "Object 2",
+                            "type": "object",
                             "description": "A formula and functions metrics query for use in aggregate queries.",
                             "fields": [
                               {
                                 "name": "aggregator",
-                                "type": "string",
+                                "type": "enum",
                                 "required": false,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1569,7 +1453,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1610,7 +1494,7 @@
                         "children": [
                           {
                             "name": "aggregation",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -1632,7 +1516,7 @@
                           },
                           {
                             "name": "interval",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -1658,7 +1542,7 @@
                       },
                       {
                         "name": "data_source",
-                        "type": "string",
+                        "type": "enum",
                         "required": true,
                         "deprecated": false,
                         "readOnly": false,
@@ -1685,7 +1569,7 @@
                           },
                           {
                             "name": "limit",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -1701,7 +1585,7 @@
                             "children": [
                               {
                                 "name": "aggregation",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1731,7 +1615,7 @@
                               },
                               {
                                 "name": "order",
-                                "type": "string",
+                                "type": "enum",
                                 "required": false,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1772,7 +1656,7 @@
                           },
                           {
                             "name": "join_type",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -1796,6 +1680,7 @@
                   },
                   {
                     "label": "Object 5",
+                    "type": "object",
                     "description": "A formula and functions aggregate filtered query. Used to filter base query results using data from another source.",
                     "fields": [
                       {
@@ -1808,6 +1693,7 @@
                         "unionOptions": [
                           {
                             "label": "Object 1",
+                            "type": "object",
                             "description": "A formula and functions events query.",
                             "fields": [
                               {
@@ -1820,7 +1706,7 @@
                                 "children": [
                                   {
                                     "name": "aggregation",
-                                    "type": "string",
+                                    "type": "enum",
                                     "required": true,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1842,7 +1728,7 @@
                                   },
                                   {
                                     "name": "interval",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1868,7 +1754,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -1904,7 +1790,7 @@
                                   },
                                   {
                                     "name": "limit",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -1920,7 +1806,7 @@
                                     "children": [
                                       {
                                         "name": "aggregation",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": true,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -1950,7 +1836,7 @@
                                       },
                                       {
                                         "name": "order",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": false,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -2003,11 +1889,12 @@
                           },
                           {
                             "label": "Object 2",
+                            "type": "object",
                             "description": "A formula and functions metrics query for use in aggregate queries.",
                             "fields": [
                               {
                                 "name": "aggregator",
-                                "type": "string",
+                                "type": "enum",
                                 "required": false,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2028,7 +1915,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2069,7 +1956,7 @@
                         "children": [
                           {
                             "name": "aggregation",
-                            "type": "string",
+                            "type": "enum",
                             "required": true,
                             "deprecated": false,
                             "readOnly": false,
@@ -2091,7 +1978,7 @@
                           },
                           {
                             "name": "interval",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -2117,7 +2004,7 @@
                       },
                       {
                         "name": "data_source",
-                        "type": "string",
+                        "type": "enum",
                         "required": true,
                         "deprecated": false,
                         "readOnly": false,
@@ -2136,6 +2023,7 @@
                         "unionOptions": [
                           {
                             "label": "Object 1",
+                            "type": "object",
                             "description": "A formula and functions events query.",
                             "fields": [
                               {
@@ -2148,7 +2036,7 @@
                                 "children": [
                                   {
                                     "name": "aggregation",
-                                    "type": "string",
+                                    "type": "enum",
                                     "required": true,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -2170,7 +2058,7 @@
                                   },
                                   {
                                     "name": "interval",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -2196,7 +2084,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2232,7 +2120,7 @@
                                   },
                                   {
                                     "name": "limit",
-                                    "type": "integer (int64)",
+                                    "type": "int64",
                                     "required": false,
                                     "deprecated": false,
                                     "readOnly": false,
@@ -2248,7 +2136,7 @@
                                     "children": [
                                       {
                                         "name": "aggregation",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": true,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -2278,7 +2166,7 @@
                                       },
                                       {
                                         "name": "order",
-                                        "type": "string",
+                                        "type": "enum",
                                         "required": false,
                                         "deprecated": false,
                                         "readOnly": false,
@@ -2331,6 +2219,7 @@
                           },
                           {
                             "label": "<data_source=reference_table>",
+                            "type": "object",
                             "description": "A reference table query for use in aggregate queries.",
                             "fields": [
                               {
@@ -2361,7 +2250,7 @@
                               },
                               {
                                 "name": "data_source",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2451,7 +2340,7 @@
                           },
                           {
                             "name": "limit",
-                            "type": "integer (int64)",
+                            "type": "int64",
                             "required": false,
                             "deprecated": false,
                             "readOnly": false,
@@ -2467,7 +2356,7 @@
                             "children": [
                               {
                                 "name": "aggregation",
-                                "type": "string",
+                                "type": "enum",
                                 "required": true,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2497,7 +2386,7 @@
                               },
                               {
                                 "name": "order",
-                                "type": "string",
+                                "type": "enum",
                                 "required": false,
                                 "deprecated": false,
                                 "readOnly": false,
@@ -2527,25 +2416,8 @@
             ]
           },
           {
-            "name": "overall_state",
-            "type": "string",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "The different states your monitor can be in.",
-            "enumValues": [
-              "Alert",
-              "Ignored",
-              "No Data",
-              "OK",
-              "Skipped",
-              "Unknown",
-              "Warn"
-            ]
-          },
-          {
             "name": "priority",
-            "type": "integer (int64)",
+            "type": "int64",
             "required": false,
             "deprecated": false,
             "readOnly": false,
@@ -2568,24 +2440,6 @@
             "description": "A list of unique role identifiers to define which roles are allowed to edit the monitor. The unique identifiers for all roles can be pulled from the [Roles API](https://docs.datadoghq.com/api/latest/roles/#list-roles) and are located in the `data.id` field. Editing a monitor includes any updates to the monitor configuration, monitor deletion, and muting of the monitor for any amount of time. You can use the [Restriction Policies API](https://docs.datadoghq.com/api/latest/restriction-policies/) to manage write authorization for individual monitors by teams and users, in addition to roles."
           },
           {
-            "name": "state",
-            "type": "object",
-            "required": false,
-            "deprecated": false,
-            "readOnly": true,
-            "description": "Wrapper object with the different monitor states.",
-            "children": [
-              {
-                "name": "groups",
-                "type": "object",
-                "required": false,
-                "deprecated": false,
-                "readOnly": false,
-                "description": "Dictionary where the keys are groups (comma separated lists of tags) and the values are\nthe list of groups your monitor is broken down on."
-              }
-            ]
-          },
-          {
             "name": "tags",
             "type": "[string]",
             "required": false,
@@ -2595,7 +2449,7 @@
           },
           {
             "name": "type",
-            "type": "string",
+            "type": "enum",
             "required": true,
             "deprecated": false,
             "readOnly": false,
@@ -2647,7 +2501,7 @@
               "children": [
                 {
                   "name": "category",
-                  "type": "string",
+                  "type": "enum",
                   "required": true,
                   "deprecated": false,
                   "readOnly": false,
@@ -2674,7 +2528,7 @@
                 },
                 {
                   "name": "resource_type",
-                  "type": "string",
+                  "type": "enum",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2695,7 +2549,7 @@
             },
             {
               "name": "created",
-              "type": "string (date-time)",
+              "type": "date-time",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -2737,7 +2591,7 @@
             },
             {
               "name": "deleted",
-              "type": "string (date-time)",
+              "type": "date-time",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -2745,7 +2599,7 @@
             },
             {
               "name": "draft_status",
-              "type": "string",
+              "type": "enum",
               "required": false,
               "deprecated": false,
               "readOnly": false,
@@ -2758,7 +2612,7 @@
             },
             {
               "name": "id",
-              "type": "integer (int64)",
+              "type": "int64",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -2774,7 +2628,7 @@
               "children": [
                 {
                   "name": "end",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2782,7 +2636,7 @@
                 },
                 {
                   "name": "id",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": true,
                   "deprecated": false,
                   "readOnly": true,
@@ -2798,7 +2652,7 @@
                 },
                 {
                   "name": "start",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2816,7 +2670,7 @@
             },
             {
               "name": "modified",
-              "type": "string (date-time)",
+              "type": "date-time",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -2914,7 +2768,7 @@
                 },
                 {
                   "name": "evaluation_delay",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2955,7 +2809,7 @@
                 },
                 {
                   "name": "min_failure_duration",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2964,7 +2818,7 @@
                 },
                 {
                   "name": "min_location_failed",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2973,7 +2827,7 @@
                 },
                 {
                   "name": "new_group_delay",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2981,7 +2835,7 @@
                 },
                 {
                   "name": "new_host_delay",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": true,
                   "readOnly": false,
@@ -2990,7 +2844,7 @@
                 },
                 {
                   "name": "no_data_timeframe",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -2998,7 +2852,7 @@
                 },
                 {
                   "name": "notification_preset_name",
-                  "type": "string",
+                  "type": "enum",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3041,7 +2895,7 @@
                 },
                 {
                   "name": "on_missing_data",
-                  "type": "string",
+                  "type": "enum",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3055,7 +2909,7 @@
                 },
                 {
                   "name": "renotify_interval",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3064,7 +2918,7 @@
                 },
                 {
                   "name": "renotify_occurrences",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3156,7 +3010,7 @@
                         },
                         {
                           "name": "hour_starts",
-                          "type": "integer (int32)",
+                          "type": "int32",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -3164,7 +3018,7 @@
                         },
                         {
                           "name": "month_starts",
-                          "type": "integer (int32)",
+                          "type": "int32",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -3234,7 +3088,7 @@
                   "children": [
                     {
                       "name": "critical",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3242,7 +3096,7 @@
                     },
                     {
                       "name": "critical_recovery",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3250,7 +3104,7 @@
                     },
                     {
                       "name": "ok",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3258,7 +3112,7 @@
                     },
                     {
                       "name": "unknown",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3266,7 +3120,7 @@
                     },
                     {
                       "name": "warning",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3274,7 +3128,7 @@
                     },
                     {
                       "name": "warning_recovery",
-                      "type": "number (double)",
+                      "type": "double",
                       "required": false,
                       "deprecated": false,
                       "readOnly": false,
@@ -3284,7 +3138,7 @@
                 },
                 {
                   "name": "timeout_h",
-                  "type": "integer (int64)",
+                  "type": "int64",
                   "required": false,
                   "deprecated": false,
                   "readOnly": false,
@@ -3301,6 +3155,7 @@
                   "unionOptions": [
                     {
                       "label": "Object 1",
+                      "type": "object",
                       "description": "A formula and functions events query.",
                       "fields": [
                         {
@@ -3313,7 +3168,7 @@
                           "children": [
                             {
                               "name": "aggregation",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -3335,7 +3190,7 @@
                             },
                             {
                               "name": "interval",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -3361,7 +3216,7 @@
                         },
                         {
                           "name": "data_source",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3397,7 +3252,7 @@
                             },
                             {
                               "name": "limit",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -3413,7 +3268,7 @@
                               "children": [
                                 {
                                   "name": "aggregation",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3443,7 +3298,7 @@
                                 },
                                 {
                                   "name": "order",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3496,11 +3351,12 @@
                     },
                     {
                       "label": "Object 2",
+                      "type": "object",
                       "description": "A formula and functions cost query.",
                       "fields": [
                         {
                           "name": "aggregator",
-                          "type": "string",
+                          "type": "enum",
                           "required": false,
                           "deprecated": false,
                           "readOnly": false,
@@ -3519,7 +3375,7 @@
                         },
                         {
                           "name": "data_source",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3550,11 +3406,12 @@
                     },
                     {
                       "label": "Object 3",
+                      "type": "object",
                       "description": "A formula and functions data quality query.",
                       "fields": [
                         {
                           "name": "data_source",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -3629,7 +3486,7 @@
                             },
                             {
                               "name": "model_type_override",
-                              "type": "string",
+                              "type": "enum",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -3670,6 +3527,7 @@
                     },
                     {
                       "label": "Object 4",
+                      "type": "object",
                       "description": "A formula and functions aggregate augmented query. Used to enrich base query results with data from a reference table.",
                       "fields": [
                         {
@@ -3682,6 +3540,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "A formula and functions events query.",
                               "fields": [
                                 {
@@ -3694,7 +3553,7 @@
                                   "children": [
                                     {
                                       "name": "aggregation",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3716,7 +3575,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3742,7 +3601,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3778,7 +3637,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3794,7 +3653,7 @@
                                       "children": [
                                         {
                                           "name": "aggregation",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -3824,7 +3683,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -3877,6 +3736,7 @@
                             },
                             {
                               "label": "<data_source=reference_table>",
+                              "type": "object",
                               "description": "A reference table query for use in aggregate queries.",
                               "fields": [
                                 {
@@ -3907,7 +3767,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -3954,6 +3814,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "A formula and functions events query.",
                               "fields": [
                                 {
@@ -3966,7 +3827,7 @@
                                   "children": [
                                     {
                                       "name": "aggregation",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -3988,7 +3849,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4014,7 +3875,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4050,7 +3911,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4066,7 +3927,7 @@
                                       "children": [
                                         {
                                           "name": "aggregation",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4096,7 +3957,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4149,11 +4010,12 @@
                             },
                             {
                               "label": "Object 2",
+                              "type": "object",
                               "description": "A formula and functions metrics query for use in aggregate queries.",
                               "fields": [
                                 {
                                   "name": "aggregator",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4174,7 +4036,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4215,7 +4077,7 @@
                           "children": [
                             {
                               "name": "aggregation",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -4237,7 +4099,7 @@
                             },
                             {
                               "name": "interval",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -4263,7 +4125,7 @@
                         },
                         {
                           "name": "data_source",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -4290,7 +4152,7 @@
                             },
                             {
                               "name": "limit",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -4306,7 +4168,7 @@
                               "children": [
                                 {
                                   "name": "aggregation",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4336,7 +4198,7 @@
                                 },
                                 {
                                   "name": "order",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4377,7 +4239,7 @@
                             },
                             {
                               "name": "join_type",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -4401,6 +4263,7 @@
                     },
                     {
                       "label": "Object 5",
+                      "type": "object",
                       "description": "A formula and functions aggregate filtered query. Used to filter base query results using data from another source.",
                       "fields": [
                         {
@@ -4413,6 +4276,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "A formula and functions events query.",
                               "fields": [
                                 {
@@ -4425,7 +4289,7 @@
                                   "children": [
                                     {
                                       "name": "aggregation",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4447,7 +4311,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4473,7 +4337,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4509,7 +4373,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4525,7 +4389,7 @@
                                       "children": [
                                         {
                                           "name": "aggregation",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4555,7 +4419,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4608,11 +4472,12 @@
                             },
                             {
                               "label": "Object 2",
+                              "type": "object",
                               "description": "A formula and functions metrics query for use in aggregate queries.",
                               "fields": [
                                 {
                                   "name": "aggregator",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4633,7 +4498,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4674,7 +4539,7 @@
                           "children": [
                             {
                               "name": "aggregation",
-                              "type": "string",
+                              "type": "enum",
                               "required": true,
                               "deprecated": false,
                               "readOnly": false,
@@ -4696,7 +4561,7 @@
                             },
                             {
                               "name": "interval",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -4722,7 +4587,7 @@
                         },
                         {
                           "name": "data_source",
-                          "type": "string",
+                          "type": "enum",
                           "required": true,
                           "deprecated": false,
                           "readOnly": false,
@@ -4741,6 +4606,7 @@
                           "unionOptions": [
                             {
                               "label": "Object 1",
+                              "type": "object",
                               "description": "A formula and functions events query.",
                               "fields": [
                                 {
@@ -4753,7 +4619,7 @@
                                   "children": [
                                     {
                                       "name": "aggregation",
-                                      "type": "string",
+                                      "type": "enum",
                                       "required": true,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4775,7 +4641,7 @@
                                     },
                                     {
                                       "name": "interval",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4801,7 +4667,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -4837,7 +4703,7 @@
                                     },
                                     {
                                       "name": "limit",
-                                      "type": "integer (int64)",
+                                      "type": "int64",
                                       "required": false,
                                       "deprecated": false,
                                       "readOnly": false,
@@ -4853,7 +4719,7 @@
                                       "children": [
                                         {
                                           "name": "aggregation",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": true,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4883,7 +4749,7 @@
                                         },
                                         {
                                           "name": "order",
-                                          "type": "string",
+                                          "type": "enum",
                                           "required": false,
                                           "deprecated": false,
                                           "readOnly": false,
@@ -4936,6 +4802,7 @@
                             },
                             {
                               "label": "<data_source=reference_table>",
+                              "type": "object",
                               "description": "A reference table query for use in aggregate queries.",
                               "fields": [
                                 {
@@ -4966,7 +4833,7 @@
                                 },
                                 {
                                   "name": "data_source",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -5056,7 +4923,7 @@
                             },
                             {
                               "name": "limit",
-                              "type": "integer (int64)",
+                              "type": "int64",
                               "required": false,
                               "deprecated": false,
                               "readOnly": false,
@@ -5072,7 +4939,7 @@
                               "children": [
                                 {
                                   "name": "aggregation",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": true,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -5102,7 +4969,7 @@
                                 },
                                 {
                                   "name": "order",
-                                  "type": "string",
+                                  "type": "enum",
                                   "required": false,
                                   "deprecated": false,
                                   "readOnly": false,
@@ -5133,7 +5000,7 @@
             },
             {
               "name": "overall_state",
-              "type": "string",
+              "type": "enum",
               "required": false,
               "deprecated": false,
               "readOnly": true,
@@ -5150,7 +5017,7 @@
             },
             {
               "name": "priority",
-              "type": "integer (int64)",
+              "type": "int64",
               "required": false,
               "deprecated": false,
               "readOnly": false,
@@ -5200,7 +5067,7 @@
             },
             {
               "name": "type",
-              "type": "string",
+              "type": "enum",
               "required": true,
               "deprecated": false,
               "readOnly": false,

--- a/astro/src/lib/api/__snapshots__/getOperationView/usage-metering.get-hourly-usage-for-lambda.json
+++ b/astro/src/lib/api/__snapshots__/getOperationView/usage-metering.get-hourly-usage-for-lambda.json
@@ -31,7 +31,7 @@
       "queryParams": [
         {
           "name": "start_hr",
-          "type": "string (date-time)",
+          "type": "string",
           "required": true,
           "deprecated": false,
           "readOnly": false,
@@ -39,7 +39,7 @@
         },
         {
           "name": "end_hr",
-          "type": "string (date-time)",
+          "type": "string",
           "required": false,
           "deprecated": false,
           "readOnly": false,

--- a/astro/src/lib/api/operationBuilder.ts
+++ b/astro/src/lib/api/operationBuilder.ts
@@ -6,7 +6,11 @@
  */
 
 import type { OpenAPIV3 } from "openapi-types";
-import { resolveRef, topLevelSchemaToFields } from "./refResolver";
+import {
+  resolveRef,
+  topLevelSchemaToFields,
+  stripReadOnlyFields,
+} from "./refResolver";
 import { buildCurlCommand } from "./curlBuilder";
 import { getRegions } from "./regionResolver";
 import type { SchemaField } from "./schemas/schemaField";
@@ -109,8 +113,11 @@ export function extractRequestBody(
   const jsonContent = content["application/json"];
   if (!jsonContent) return undefined;
 
+  // Read-only fields are omitted from request bodies: a client cannot send
+  // them. Responses keep theirs, so the filter belongs here rather than in
+  // `topLevelSchemaToFields`.
   const schema = jsonContent.schema
-    ? topLevelSchemaToFields(spec, jsonContent.schema)
+    ? stripReadOnlyFields(topLevelSchemaToFields(spec, jsonContent.schema))
     : [];
 
   const examples: Array<{ name: string; value: string }> = [];

--- a/astro/src/lib/api/refResolver.test.ts
+++ b/astro/src/lib/api/refResolver.test.ts
@@ -8,6 +8,7 @@ import {
   unionOptionLabels,
   stripReadOnlyFields,
 } from "@lib/api/refResolver";
+import type { SchemaField } from "@lib/api/schemas/schemaField";
 
 describe("resolveRef", () => {
   it("resolves a simple $ref path", () => {
@@ -950,7 +951,7 @@ describe("union option types", () => {
 });
 
 describe("stripReadOnlyFields", () => {
-  const field = (name: string, extra: object = {}) => ({
+  const field = (name: string, extra: Partial<SchemaField> = {}) => ({
     name,
     type: "string",
     required: false,
@@ -1015,6 +1016,7 @@ describe("stripReadOnlyFields", () => {
         unionOptions: [
           {
             label: "<type=a>",
+            type: "object",
             fields: [field("keep"), field("drop", { readOnly: true })],
           },
         ],

--- a/astro/src/lib/api/refResolver.test.ts
+++ b/astro/src/lib/api/refResolver.test.ts
@@ -6,6 +6,7 @@ import {
   topLevelSchemaToFields,
   getBestDiscriminant,
   unionOptionLabels,
+  stripReadOnlyFields,
 } from "@lib/api/refResolver";
 
 describe("resolveRef", () => {
@@ -723,5 +724,322 @@ describe("unionOptionLabels", () => {
       { type: "object", properties: { type: { type: "string", enum: ["b"] } } },
     ];
     expect(unionOptionLabels({}, items)[0]).not.toContain("&lt;");
+  });
+});
+
+describe("type column: enum and format", () => {
+  const typeOf = (schema: object) =>
+    schemaToFields({}, { type: "object", properties: { f: schema } })[0].type;
+
+  it("reports enum for an enumerated field, not its base type", () => {
+    // Hugo's typeColumn: `else if (value.enum) typeVal = 'enum'`.
+    expect(typeOf({ type: "string", enum: ["contains", "isNot"] })).toBe("enum");
+    expect(typeOf({ type: "integer", enum: [1, 2] })).toBe("enum");
+  });
+
+  it("still carries the permitted values in enumValues", () => {
+    const [field] = schemaToFields(
+      {},
+      {
+        type: "object",
+        properties: { f: { type: "string", enum: ["a", "b"] } },
+      },
+    );
+    expect(field.type).toBe("enum");
+    expect(field.enumValues).toEqual(["a", "b"]);
+  });
+
+  it("reports enum ahead of format when both are present", () => {
+    expect(typeOf({ type: "string", format: "uuid", enum: ["x"] })).toBe("enum");
+  });
+
+  it("reports the format alone, not `type (format)`", () => {
+    expect(typeOf({ type: "integer", format: "int64" })).toBe("int64");
+    expect(typeOf({ type: "string", format: "date-time" })).toBe("date-time");
+    expect(typeOf({ type: "number", format: "double" })).toBe("double");
+    expect(typeOf({ type: "string", format: "uuid" })).toBe("uuid");
+  });
+
+  it("falls back to the base type when there is no format", () => {
+    expect(typeOf({ type: "string" })).toBe("string");
+    expect(typeOf({ type: "boolean" })).toBe("boolean");
+  });
+
+  it("does NOT apply the format rule to parameters", () => {
+    // Parameters render from `layouts/partials/api/arguments.html`, which
+    // prints `.schema.type` and ignores `format`. So `list_id` is `integer`,
+    // not `int64` — the opposite of the body rule above.
+    const params = [
+      {
+        name: "list_id",
+        in: "path",
+        schema: { type: "integer", format: "int64" },
+      },
+      { name: "start", in: "query", schema: { type: "string", format: "date-time" } },
+      { name: "name", in: "query", schema: { type: "string" } },
+    ];
+    expect(paramsToFields({}, params).map((f) => f.type)).toEqual([
+      "integer",
+      "string",
+      "string",
+    ]);
+  });
+
+  it("still reports enum for an enumerated parameter", () => {
+    const params = [
+      {
+        name: "sort",
+        in: "query",
+        schema: { type: "string", enum: ["asc", "desc"] },
+      },
+    ];
+    const [field] = paramsToFields({}, params);
+    expect(field.type).toBe("enum");
+    expect(field.enumValues).toEqual(["asc", "desc"]);
+  });
+
+  it("resolves a $ref'd parameter schema before typing it", () => {
+    const spec = {
+      components: {
+        schemas: {
+          PageSize: { type: "integer", format: "int32" },
+        },
+      },
+    };
+    const params = [
+      {
+        name: "page_size",
+        in: "query",
+        schema: { $ref: "#/components/schemas/PageSize" },
+      },
+    ];
+    expect(paramsToFields(spec, params)[0].type).toBe("integer");
+  });
+});
+
+describe("union option types", () => {
+  it("reports a scalar variant's own type, not object", () => {
+    // SyntheticsAssertionTargetValue: a number branch and a string branch.
+    // Hugo renders these as `double` and `string`.
+    const spec = {
+      components: {
+        schemas: {
+          TargetValueNumber: {
+            description: "Numeric value.",
+            type: "number",
+            format: "double",
+          },
+          TargetValueString: { description: "String value.", type: "string" },
+        },
+      },
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        target: {
+          oneOf: [
+            { $ref: "#/components/schemas/TargetValueNumber" },
+            { $ref: "#/components/schemas/TargetValueString" },
+          ],
+        },
+      },
+    };
+
+    const [target] = schemaToFields(spec, schema);
+    expect(target.type).toBe("oneOf");
+    expect(target.unionOptions?.map((o) => [o.label, o.type])).toEqual([
+      ["Object 1", "double"],
+      ["Object 2", "string"],
+    ]);
+  });
+
+  it("gives a scalar variant no nested rows", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        value: { oneOf: [{ type: "string" }, { type: "boolean" }] },
+      },
+    };
+    const [value] = schemaToFields({}, schema);
+    expect(value.unionOptions?.map((o) => o.fields.length)).toEqual([0, 0]);
+    expect(value.unionOptions?.map((o) => o.type)).toEqual([
+      "string",
+      "boolean",
+    ]);
+  });
+
+  it("keeps object variants as object, with their rows", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        thing: {
+          oneOf: [
+            { type: "object", properties: { a: { type: "string" } } },
+            { type: "string" },
+          ],
+        },
+      },
+    };
+    const [thing] = schemaToFields({}, schema);
+    expect(thing.unionOptions?.map((o) => o.type)).toEqual([
+      "object",
+      "string",
+    ]);
+    expect(thing.unionOptions?.[0].fields.map((f) => f.name)).toEqual(["a"]);
+    expect(thing.unionOptions?.[1].fields).toEqual([]);
+  });
+
+  it("reports an array variant with its item type", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        thing: {
+          oneOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "string" },
+          ],
+        },
+      },
+    };
+    expect(
+      schemaToFields({}, schema)[0].unionOptions?.map((o) => o.type),
+    ).toEqual(["[string]", "string"]);
+  });
+
+  it("carries enum values from a scalar variant onto the option", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        thing: {
+          oneOf: [
+            { type: "string", enum: ["a", "b"] },
+            { type: "integer" },
+          ],
+        },
+      },
+    };
+    const [thing] = schemaToFields({}, schema);
+    expect(thing.unionOptions?.[0].type).toBe("enum");
+    expect(thing.unionOptions?.[0].enumValues).toEqual(["a", "b"]);
+    expect(thing.unionOptions?.[1].type).toBe("integer");
+  });
+
+  it("reports a nested union variant as <oneOf>", () => {
+    const spec = {
+      components: {
+        schemas: {
+          Nested: { oneOf: [{ type: "string" }, { type: "integer" }] },
+        },
+      },
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        thing: {
+          oneOf: [
+            { $ref: "#/components/schemas/Nested" },
+            { type: "string" },
+          ],
+        },
+      },
+    };
+    expect(
+      schemaToFields(spec, schema)[0].unionOptions?.map((o) => o.type),
+    ).toEqual(["<oneOf>", "string"]);
+  });
+});
+
+describe("stripReadOnlyFields", () => {
+  const field = (name: string, extra: object = {}) => ({
+    name,
+    type: "string",
+    required: false,
+    deprecated: false,
+    readOnly: false,
+    description: "",
+    ...extra,
+  });
+
+  it("drops read-only fields and keeps the rest", () => {
+    const fields = [
+      field("name"),
+      field("creator", { readOnly: true }),
+      field("monitor_id", { readOnly: true }),
+      field("tags"),
+    ];
+    expect(stripReadOnlyFields(fields).map((f) => f.name)).toEqual([
+      "name",
+      "tags",
+    ]);
+  });
+
+  it("drops read-only fields nested in children", () => {
+    const fields = [
+      field("data", {
+        type: "object",
+        children: [field("attributes"), field("id", { readOnly: true })],
+      }),
+    ];
+    const [data] = stripReadOnlyFields(fields);
+    expect(data.children?.map((c) => c.name)).toEqual(["attributes"]);
+  });
+
+  it("drops a read-only object together with its subtree", () => {
+    const fields = [
+      field("creator", {
+        type: "object",
+        readOnly: true,
+        children: [field("email"), field("handle")],
+      }),
+      field("name"),
+    ];
+    expect(stripReadOnlyFields(fields).map((f) => f.name)).toEqual(["name"]);
+  });
+
+  it("removes the children key when every child was read-only", () => {
+    const fields = [
+      field("wrapper", {
+        type: "object",
+        children: [field("a", { readOnly: true })],
+      }),
+    ];
+    const [wrapper] = stripReadOnlyFields(fields);
+    expect(wrapper.children).toBeUndefined();
+    expect("children" in wrapper).toBe(false);
+  });
+
+  it("filters inside union options", () => {
+    const fields = [
+      field("variant", {
+        type: "oneOf",
+        unionOptions: [
+          {
+            label: "<type=a>",
+            fields: [field("keep"), field("drop", { readOnly: true })],
+          },
+        ],
+      }),
+    ];
+    const [variant] = stripReadOnlyFields(fields);
+    expect(variant.unionOptions?.[0].fields.map((f) => f.name)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("does not mutate the input tree", () => {
+    const fields = [
+      field("data", {
+        type: "object",
+        children: [field("id", { readOnly: true }), field("name")],
+      }),
+    ];
+    stripReadOnlyFields(fields);
+    expect(fields[0].children).toHaveLength(2);
+  });
+
+  it("returns an empty array when everything is read-only", () => {
+    expect(
+      stripReadOnlyFields([field("a", { readOnly: true })]),
+    ).toEqual([]);
   });
 });

--- a/astro/src/lib/api/refResolver.ts
+++ b/astro/src/lib/api/refResolver.ts
@@ -304,6 +304,81 @@ export function topLevelSchemaToFields(spec: any, schema: any): SchemaField[] {
 }
 
 /**
+ * Build the option rows for a `oneOf`/`anyOf`.
+ *
+ * Each option carries its *own* branch type. Hugo keys the union's child rows
+ * by label and renders each one as an ordinary row, so a numeric branch shows
+ * `double` and a string branch shows `string` — not a blanket `object`. A
+ * scalar branch therefore needs no nested row at all: `schemaToFields` returns
+ * a single anonymous leaf for it, which would render as an unnamed child under
+ * the option, so that leaf is folded into the option itself.
+ *
+ * @param spec      The full parsed OpenAPI spec object.
+ * @param variants  The raw `oneOf`/`anyOf` branch schemas (may be `$ref`s).
+ * @param visited   `$ref`s already seen on this path.
+ * @param level     Row-nesting level of the union field itself.
+ */
+function buildUnionOptions(
+  spec: any,
+  variants: any[],
+  visited: Set<string>,
+  level: number,
+): NonNullable<SchemaField["unionOptions"]> {
+  const labels = unionOptionLabels(spec, variants);
+
+  return variants.map((variant: any, idx: number) => {
+    const fields = schemaToFields(spec, variant, new Set(visited), level + 2);
+
+    // A scalar branch yields one anonymous leaf and nothing else; its type
+    // belongs on the option row rather than on a nested unnamed row.
+    const leaf =
+      fields.length === 1 &&
+      fields[0].name === "" &&
+      !fields[0].children &&
+      !fields[0].unionOptions
+        ? fields[0]
+        : undefined;
+
+    return {
+      label: labels[idx],
+      type: leaf ? leaf.type : unionOptionType(spec, variant),
+      description: variantDescription(spec, variant),
+      ...(leaf?.enumValues ? { enumValues: leaf.enumValues } : {}),
+      ...(leaf?.defaultValue !== undefined
+        ? { defaultValue: leaf.defaultValue }
+        : {}),
+      fields: leaf ? [] : fields,
+    };
+  });
+}
+
+/**
+ * Display type for a union branch that has nested rows of its own.
+ *
+ * Mirrors the type a property row would get for the same schema, so an
+ * object branch reads `object`, an array branch `[object]`, and a branch that
+ * is itself a union `<oneOf>`.
+ */
+function unionOptionType(spec: any, variant: any): string {
+  let resolved = variant;
+  if (variant?.$ref) {
+    resolved = resolveRef(spec, variant.$ref) ?? variant;
+  }
+  if (resolved.allOf) {
+    resolved = mergeAllOf(resolved.allOf, spec);
+  }
+
+  if (resolved.oneOf) return "<oneOf>";
+  if (resolved.anyOf) return "<anyOf>";
+  if (resolved.type === "array") {
+    return `[${resolved.items ? resolveItemTypeName(resolved.items, spec) : "any"}]`;
+  }
+  if (resolved.type === "object" || resolved.properties) return "object";
+
+  return displayType(resolved);
+}
+
+/**
  * Convert an OpenAPI schema object into a `SchemaField[]` tree suitable for
  * rendering in UI components.
  *
@@ -362,14 +437,7 @@ export function schemaToFields(
   const unionKey = schema.oneOf ? "oneOf" : schema.anyOf ? "anyOf" : null;
   if (unionKey) {
     const variants: any[] = schema[unionKey];
-    const labels = unionOptionLabels(spec, variants);
-    const unionOptions = variants.map((variant: any, idx: number) => {
-      return {
-        label: labels[idx],
-        description: variantDescription(spec, variant),
-        fields: schemaToFields(spec, variant, new Set(visited), level + 2),
-      };
-    });
+    const unionOptions = buildUnionOptions(spec, variants, visited, level);
 
     // Return a single synthetic field that carries the union options
     return [
@@ -464,6 +532,54 @@ export function schemaToFields(
   return [field];
 }
 
+/**
+ * Drop read-only fields from a field tree, at every depth.
+ *
+ * A client cannot send a read-only field, so it does not belong in a request
+ * body. Hugo emits the rows and hides them with
+ * `.table-request .isReadOnly { display: none }`, scoped so response tables
+ * still show them — which is where read-only fields belong, since `id` and
+ * `created_at` are exactly what a response returns.
+ *
+ * Filtering the tree rather than hiding rows in CSS also covers the plaintext
+ * `.md` output and the serialized view, neither of which a stylesheet reaches.
+ *
+ * Removing a read-only object removes its subtree, matching Hugo, where
+ * hiding a row hides the nested rows it contains.
+ *
+ * @param fields  Field tree to filter.
+ * @returns A new tree with read-only fields omitted.
+ */
+export function stripReadOnlyFields(fields: SchemaField[]): SchemaField[] {
+  const kept: SchemaField[] = [];
+
+  for (const field of fields) {
+    if (field.readOnly) continue;
+
+    const next: SchemaField = { ...field };
+
+    if (field.children) {
+      const children = stripReadOnlyFields(field.children);
+      if (children.length > 0) {
+        next.children = children;
+      } else {
+        delete next.children;
+      }
+    }
+
+    if (field.unionOptions) {
+      next.unionOptions = field.unionOptions.map((option) => ({
+        ...option,
+        fields: stripReadOnlyFields(option.fields),
+      }));
+    }
+
+    kept.push(next);
+  }
+
+  return kept;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Parameter → SchemaField[] conversion                               */
 /* ------------------------------------------------------------------ */
@@ -513,7 +629,7 @@ export function paramsToFields(spec: any, params: any[]): SchemaField[] {
 
     const field: SchemaField = {
       name,
-      type: displayType(paramSchema),
+      type: parameterType(paramSchema),
       required,
       deprecated,
       readOnly: paramSchema.readOnly === true,
@@ -539,16 +655,45 @@ export function paramsToFields(spec: any, params: any[]): SchemaField[] {
  * Build a display type string for a schema. Handles format annotations
  * (e.g. "string (date-time)") and enums.
  */
+/**
+ * Display type for a path, query, or header parameter row.
+ *
+ * Parameters are rendered by a different Hugo template than request and
+ * response bodies — `layouts/partials/api/arguments.html` — and it reports
+ * `.schema.type` directly. `format` is ignored there, so `list_id` shows
+ * `integer` rather than `int64`. This is deliberately not `displayType`,
+ * which applies the body rules.
+ *
+ * Hugo substitutes `enum` in the query-parameter table only; the path and
+ * header tables print the bare type. No parameter in either spec currently
+ * carries an `enum`, so the substitution is applied uniformly here rather
+ * than reproducing an asymmetry that never renders.
+ */
+function parameterType(schema: any): string {
+  if (schema.enum) {
+    return "enum";
+  }
+  return schema.type ?? "object";
+}
+
 function displayType(schema: any): string {
   const base: string = schema.type ?? "object";
 
+  // An enumerated field reports `enum` rather than its underlying type,
+  // matching Hugo's `typeColumn`. The permitted values travel separately in
+  // `enumValues` and render in the description column.
   if (schema.enum) {
-    // Show the underlying type; callers also set `enumValues`
-    return schema.format ? `${base} (${schema.format})` : base;
+    return "enum";
   }
 
+  // A `format` supersedes the base type, as in Hugo's `format || type`.
+  // OpenAPI defines `format` as a refinement of `type`, and every format in
+  // these specs implies exactly one base type (`int64` → integer,
+  // `date-time` → string), so reporting the format alone loses nothing while
+  // saying strictly more. The invariant that makes this safe is asserted in
+  // `tests/integration/refResolver.full-spec.test.ts`.
   if (schema.format) {
-    return `${base} (${schema.format})`;
+    return schema.format;
   }
 
   return base;
@@ -652,14 +797,7 @@ function propertyToField(
   const unionKey = resolved.oneOf ? "oneOf" : resolved.anyOf ? "anyOf" : null;
   if (unionKey) {
     const variants: any[] = resolved[unionKey];
-    const labels = unionOptionLabels(spec, variants);
-    const unionOptions = variants.map((variant: any, idx: number) => {
-      return {
-        label: labels[idx],
-        description: variantDescription(spec, variant),
-        fields: schemaToFields(spec, variant, new Set(nextVisited), level + 2),
-      };
-    });
+    const unionOptions = buildUnionOptions(spec, variants, nextVisited, level);
 
     return {
       name,

--- a/astro/src/lib/api/schemas/schemaField.ts
+++ b/astro/src/lib/api/schemas/schemaField.ts
@@ -31,11 +31,25 @@ export const SchemaFieldSchema = z.strictObject({
       .array(
         z.strictObject({
           label: z.string(),
+          type: z
+            .string()
+            .describe(
+              'The variant schema\'s own display type, e.g. "object", "string", "double", "[object]". Hugo renders each option row with the branch\'s type, not a blanket "object".',
+            ),
           description: z
             .string()
             .optional()
             .describe("The variant schema's own description, if any"),
-          fields: z.array(SchemaFieldSchema),
+          enumValues: z
+            .array(z.string())
+            .optional()
+            .describe("Permitted values when the variant is an enum"),
+          defaultValue: z.string().optional(),
+          fields: z
+            .array(SchemaFieldSchema)
+            .describe(
+              "The variant's nested rows. Empty when the variant is a scalar, since its type is carried on the option itself.",
+            ),
         }),
       )
       .optional()

--- a/astro/src/lib/site/websitesModulesPath.ts
+++ b/astro/src/lib/site/websitesModulesPath.ts
@@ -161,7 +161,7 @@ export function resolveWebsitesModulesPath(astroConfigUrl: string): string {
   }
 
   const sibling = fileURLToPath(
-    new URL("../../../../../../dd/websites-modules", astroConfigUrl),
+    new URL("../../websites-modules", astroConfigUrl),
   );
   attempted.push(`sibling checkout: ${sibling}`);
   if (existsSync(sibling)) {

--- a/astro/src/lib/site/websitesModulesPath.ts
+++ b/astro/src/lib/site/websitesModulesPath.ts
@@ -161,7 +161,7 @@ export function resolveWebsitesModulesPath(astroConfigUrl: string): string {
   }
 
   const sibling = fileURLToPath(
-    new URL("../../websites-modules", astroConfigUrl),
+    new URL("../../../../../../dd/websites-modules", astroConfigUrl),
   );
   attempted.push(`sibling checkout: ${sibling}`);
   if (existsSync(sibling)) {

--- a/astro/tests/headless/api-html-snapshots/06-dashboards-get-a-dashboard.html
+++ b/astro/tests/headless/api-html-snapshots/06-dashboards-get-a-dashboard.html
@@ -411,7 +411,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Creation date of the dashboard.</span>
@@ -491,7 +491,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Layout type of the dashboard.</span>
@@ -511,7 +511,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Modification date of the dashboard.</span>
@@ -545,7 +545,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span
@@ -631,7 +631,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string (uuid)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">uuid</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>UUID of the tab.</span>
@@ -1277,7 +1277,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Number of decimal to show. If not defined, will use the raw value.</span>
@@ -1299,7 +1299,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>How to align the text on the widget.</span>
@@ -1344,7 +1344,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>How to align the text on the widget.</span>
@@ -1392,7 +1392,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Type of the alert value widget.</span
@@ -1762,7 +1762,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Layout of the legend.</span>
@@ -2131,9 +2131,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2228,9 +2226,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2350,7 +2346,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2504,9 +2500,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2741,9 +2735,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2838,9 +2830,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -2960,7 +2950,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3114,9 +3104,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3213,7 +3201,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Type of display to use for the request.</span>
@@ -3376,9 +3364,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3473,9 +3459,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3595,7 +3579,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3749,9 +3733,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3915,7 +3897,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -3990,7 +3972,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4017,7 +3999,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4092,7 +4074,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4248,7 +4230,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4314,9 +4296,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >number (double)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4411,9 +4391,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4437,7 +4415,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4629,7 +4607,7 @@
                                               >
                                             </div>
                                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                             </div>
                                             <div
                                               class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4750,7 +4728,7 @@
                                               >
                                             </div>
                                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                             </div>
                                             <div
                                               class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4824,7 +4802,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4952,9 +4930,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5118,9 +5094,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5215,9 +5189,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5337,7 +5309,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5491,9 +5463,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5821,9 +5791,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -5918,9 +5886,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6040,7 +6006,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6194,9 +6160,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6382,9 +6346,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a"
-                                          >integer (int64)</span
-                                        >
+                                        <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6596,9 +6558,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6693,9 +6653,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6815,7 +6773,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -6969,9 +6927,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7182,7 +7138,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7239,7 +7195,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7316,7 +7272,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7440,7 +7396,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7477,9 +7433,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a"
-                                              >integer (int64)</span
-                                            >
+                                            <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7557,7 +7511,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7665,7 +7619,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">object</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">[object]</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7763,9 +7717,7 @@
                                                 >
                                               </div>
                                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                                <span class="schema-table__type _schema-table__type_d7636a"
-                                                  >integer (int64)</span
-                                                >
+                                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                               </div>
                                               <div
                                                 class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7890,9 +7842,7 @@
                                               >
                                             </div>
                                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                              <span class="schema-table__type _schema-table__type_d7636a"
-                                                >integer (int64)</span
-                                              >
+                                              <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                             </div>
                                             <div
                                               class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -7963,9 +7913,7 @@
                                                 >
                                               </div>
                                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                                <span class="schema-table__type _schema-table__type_d7636a"
-                                                  >string</span
-                                                >
+                                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                               </div>
                                               <div
                                                 class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8028,9 +7976,7 @@
                                                 >
                                               </div>
                                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                                <span class="schema-table__type _schema-table__type_d7636a"
-                                                  >string</span
-                                                >
+                                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                               </div>
                                               <div
                                                 class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8256,7 +8202,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8313,7 +8259,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8364,9 +8310,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8440,7 +8384,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8593,7 +8537,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8833,7 +8777,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -8939,7 +8883,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9172,7 +9116,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9257,7 +9201,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9510,7 +9454,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9542,7 +9486,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9681,7 +9625,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9708,7 +9652,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9736,7 +9680,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9816,7 +9760,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9889,7 +9833,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -9945,7 +9889,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10024,7 +9968,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span
@@ -10190,9 +10134,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10287,9 +10229,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10409,7 +10349,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10563,9 +10503,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10800,9 +10738,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10897,9 +10833,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11019,7 +10953,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11173,9 +11107,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11339,7 +11271,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11366,7 +11298,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11393,7 +11325,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11745,7 +11677,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11847,7 +11779,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11875,7 +11807,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11903,9 +11835,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a"
-                                          >integer (int64)</span
-                                        >
+                                        <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11974,9 +11904,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a"
-                                          >integer (int64)</span
-                                        >
+                                        <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12025,9 +11953,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a"
-                                          >integer (int64)</span
-                                        >
+                                        <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12052,7 +11978,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12101,7 +12027,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>How to align the text on the widget.</span>
@@ -12149,7 +12075,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Type of the timeseries widget.</span
@@ -12439,7 +12365,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Layout type of the group.</span>
@@ -12509,7 +12435,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>How to align the text on the widget.</span>
@@ -12535,7 +12461,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Type of the group widget.</span
@@ -12630,7 +12556,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>ID of the widget.</span>
@@ -12697,7 +12623,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The height of the widget. Should be a non-negative integer.</span>
@@ -12747,7 +12673,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The width of the widget. Should be a non-negative integer.</span>
@@ -12770,7 +12696,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -12796,7 +12722,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span

--- a/astro/tests/headless/api-html-snapshots/07-incidents-create-an-incident.html
+++ b/astro/tests/headless/api-html-snapshots/07-incidents-create-an-incident.html
@@ -524,7 +524,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Type of the Markdown timeline cell.</span
@@ -886,7 +886,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Users resource type.</span
@@ -914,7 +914,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>Incident resource type.</span
@@ -1237,7 +1237,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp of when the incident was archived.</span>
@@ -1257,7 +1257,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The incident case id.</span>
@@ -1277,7 +1277,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when the incident was created.</span>
@@ -1299,7 +1299,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -1325,7 +1325,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when customers were no longer impacted by the incident.</span>
@@ -1369,7 +1369,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when customers began being impacted by the incident.</span>
@@ -1411,7 +1411,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when the incident was declared.</span>
@@ -1539,7 +1539,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when the incident was detected.</span>
@@ -1621,7 +1621,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp when the incident was last modified.</span>
@@ -1816,7 +1816,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monotonically increasing integer ID for the incident.</span>
@@ -1836,7 +1836,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -1859,7 +1859,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The incident severity.</span>
@@ -1904,7 +1904,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -1929,7 +1929,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -1954,7 +1954,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -1980,7 +1980,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -2226,7 +2226,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>The incident attachment resource type.</span
@@ -2367,7 +2367,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Users resource type.</span
@@ -2508,7 +2508,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Users resource type.</span
@@ -2649,7 +2649,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Users resource type.</span
@@ -2788,7 +2788,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>The incident impacts type.</span>
@@ -2926,7 +2926,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Integration metadata resource type.</span
@@ -3067,7 +3067,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Users resource type.</span
@@ -3206,7 +3206,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>The incident responders type.</span>
@@ -3344,7 +3344,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>The incident user defined fields type.</span>
@@ -3373,7 +3373,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Incident resource type.</span
@@ -3638,7 +3638,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Users resource type.</span
@@ -3840,7 +3840,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>The type of the attachment.</span>
@@ -3863,9 +3863,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a"
-                                      >string (date-time)</span
-                                    >
+                                    <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Timestamp when the attachment was last modified.</span>
@@ -4066,7 +4064,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4211,7 +4209,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -4245,7 +4243,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The incident attachment resource type.</span

--- a/astro/tests/headless/api-html-snapshots/08-aws-integration-list.html
+++ b/astro/tests/headless/api-html-snapshots/08-aws-integration-list.html
@@ -733,7 +733,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span
@@ -937,7 +937,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp of when the account integration was created.</span>
@@ -1673,7 +1673,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Timestamp of when the account integration was updated.</span>
@@ -2055,7 +2055,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>AWS Account resource type.</span

--- a/astro/tests/headless/api-html-snapshots/09-monitors-create-a-monitor.html
+++ b/astro/tests/headless/api-html-snapshots/09-monitors-create-a-monitor.html
@@ -774,7 +774,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>Indicates the type of asset this entity represents on a monitor.</span>
@@ -839,7 +839,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>Type of internal Datadog resource associated with a monitor asset.</span>
@@ -873,116 +873,6 @@
                       </div>
                     </div>
                     <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="created"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">created</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Timestamp of the monitor creation.</span>
-                      </div>
-                    </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="creator"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <button
-                          type="button"
-                          class="schema-table__toggle _schema-table__toggle_d7636a"
-                          aria-expanded="false"
-                          aria-label="Toggle creator"
-                        >
-                          <svg class="expand-chevron" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-                            <path d="M3 1 L7 5 L3 9" fill="none" stroke="currentColor" stroke-width="1.5"></path>
-                          </svg></button
-                        ><span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">creator</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">object</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Object describing the creator of the shared element.</span>
-                      </div>
-                    </div>
-                    <div class="schema-table__children _schema-table__children_d7636a" hidden>
-                      <div class="schema-table__row _schema-table__row_d7636a" data-field-name="email" data-depth="1">
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">email</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span>Email of the creator.</span>
-                        </div>
-                      </div>
-                      <div class="schema-table__row _schema-table__row_d7636a" data-field-name="handle" data-depth="1">
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">handle</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span>Handle of the creator.</span>
-                        </div>
-                      </div>
-                      <div class="schema-table__row _schema-table__row_d7636a" data-field-name="name" data-depth="1">
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">name</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span>Name of the creator.</span>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="deleted"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">deleted</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Whether or not the monitor is deleted. (Always <code>null</code>)</span>
-                      </div>
-                    </div>
-                    <div
                       class="schema-table__row _schema-table__row_d7636a"
                       data-field-name="draft_status"
                       data-depth="0"
@@ -993,7 +883,7 @@
                         >
                       </div>
                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                       </div>
                       <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                         <span
@@ -1009,23 +899,6 @@
                         <div class="schema-table__enum _schema-table__enum_d7636a">
                           Allowed enum values: <code>draft, published</code>
                         </div>
-                      </div>
-                    </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="id"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">id</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>ID of this monitor.</span>
                       </div>
                     </div>
                     <div
@@ -1065,33 +938,10 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>POSIX timestamp to end the downtime.</span>
-                        </div>
-                      </div>
-                      <div
-                        class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                        data-field-name="id"
-                        data-depth="1"
-                      >
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">id</code
-                            ><span class="schema-table__required _schema-table__required_d7636a">
-                              [required]</span
-                            ></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span>The downtime ID.</span>
                         </div>
                       </div>
                       <div class="schema-table__row _schema-table__row_d7636a" data-field-name="scope" data-depth="1">
@@ -1125,7 +975,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>POSIX timestamp to start the downtime.</span>
@@ -1143,40 +993,6 @@
                       </div>
                       <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                         <span>A message to include with notifications for this monitor.</span>
-                      </div>
-                    </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="modified"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">modified</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Last timestamp when the monitor was edited.</span>
-                      </div>
-                    </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="multi"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">multi</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">boolean</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Whether or not the monitor is broken down on different groups.</span>
                       </div>
                     </div>
                     <div class="schema-table__row _schema-table__row_d7636a" data-field-name="name" data-depth="0">
@@ -1215,115 +1031,6 @@
                       </div>
                     </div>
                     <div class="schema-table__children _schema-table__children_d7636a" hidden>
-                      <div
-                        class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                        data-field-name="aggregation"
-                        data-depth="1"
-                      >
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <button
-                            type="button"
-                            class="schema-table__toggle _schema-table__toggle_d7636a"
-                            aria-expanded="false"
-                            aria-label="Toggle aggregation"
-                          >
-                            <svg class="expand-chevron" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-                              <path d="M3 1 L7 5 L3 9" fill="none" stroke="currentColor" stroke-width="1.5"></path>
-                            </svg></button
-                          ><span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">aggregation</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">object</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span>Type of aggregation performed in the monitor query.</span>
-                        </div>
-                      </div>
-                      <div class="schema-table__children _schema-table__children_d7636a" hidden>
-                        <div
-                          class="schema-table__row _schema-table__row_d7636a"
-                          data-field-name="group_by"
-                          data-depth="2"
-                        >
-                          <div
-                            class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                            style="padding-left: calc(var(--space-md) + 40px)"
-                          >
-                            <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                              ><code class="schema-table__name _schema-table__name_d7636a">group_by</code></span
-                            >
-                          </div>
-                          <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                          </div>
-                          <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                            <span>Group to break down the monitor on.</span>
-                          </div>
-                        </div>
-                        <div
-                          class="schema-table__row _schema-table__row_d7636a"
-                          data-field-name="metric"
-                          data-depth="2"
-                        >
-                          <div
-                            class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                            style="padding-left: calc(var(--space-md) + 40px)"
-                          >
-                            <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                              ><code class="schema-table__name _schema-table__name_d7636a">metric</code></span
-                            >
-                          </div>
-                          <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                          </div>
-                          <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                            <span>Metric name used in the monitor.</span>
-                          </div>
-                        </div>
-                        <div class="schema-table__row _schema-table__row_d7636a" data-field-name="type" data-depth="2">
-                          <div
-                            class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                            style="padding-left: calc(var(--space-md) + 40px)"
-                          >
-                            <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                              ><code class="schema-table__name _schema-table__name_d7636a">type</code></span
-                            >
-                          </div>
-                          <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                          </div>
-                          <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                            <span>Metric type used in the monitor.</span>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a schema-table__row--deprecated _schema-table__row--deprecated_d7636a"
-                        data-field-name="device_ids"
-                        data-depth="1"
-                      >
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">device_ids</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">[string]</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <strong class="schema-table__deprecated-label _schema-table__deprecated-label_d7636a"
-                            >DEPRECATED</strong
-                          ><span>IDs of the device the Synthetics monitor is running on.</span>
-                        </div>
-                      </div>
                       <div
                         class="schema-table__row _schema-table__row_d7636a"
                         data-field-name="enable_logs_sample"
@@ -1407,7 +1114,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1542,7 +1249,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1569,7 +1276,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1596,7 +1303,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1620,7 +1327,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <strong class="schema-table__deprecated-label _schema-table__deprecated-label_d7636a"
@@ -1648,7 +1355,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1675,7 +1382,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span>Toggles the display of additional content sent in the monitor notification.</span
@@ -1781,7 +1488,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1812,7 +1519,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -1839,7 +1546,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -2131,7 +1838,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">integer (int32)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">int32</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span
@@ -2153,7 +1860,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">integer (int32)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">int32</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span
@@ -2348,7 +2055,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor <code>CRITICAL</code> threshold.</span>
@@ -2370,7 +2077,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor <code>CRITICAL</code> recovery threshold.</span>
@@ -2386,7 +2093,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor <code>OK</code> threshold.</span>
@@ -2406,7 +2113,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor UNKNOWN threshold.</span>
@@ -2426,7 +2133,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor <code>WARNING</code> threshold.</span>
@@ -2446,7 +2153,7 @@
                             >
                           </div>
                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                            <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                            <span class="schema-table__type _schema-table__type_d7636a">double</span>
                           </div>
                           <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                             <span>The monitor <code>WARNING</code> recovery threshold.</span>
@@ -2467,7 +2174,7 @@
                           >
                         </div>
                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                         </div>
                         <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                           <span
@@ -2598,7 +2305,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Aggregation methods for event platform queries.</span>
@@ -2626,7 +2333,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>A time interval in milliseconds.</span>
@@ -2693,7 +2400,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Data source for event platform-based queries.</span>
@@ -2779,7 +2486,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Number of groups to return.</span>
@@ -2843,7 +2550,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Aggregation methods for event platform queries.</span>
@@ -2891,7 +2598,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Direction of sort.</span
@@ -3056,7 +2763,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Aggregation methods for metric queries.</span>
@@ -3083,7 +2790,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Data source for cost queries.</span>
@@ -3186,7 +2893,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Data source for data quality queries.</span>
@@ -3406,7 +3113,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Override for the model type used in anomaly detection.</span>
@@ -3660,7 +3367,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Aggregation methods for event platform queries.</span>
@@ -3688,7 +3395,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>A time interval in milliseconds.</span>
@@ -3755,7 +3462,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for event platform-based queries.</span>
@@ -3846,7 +3553,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Number of groups to return.</span>
@@ -3910,7 +3617,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -3958,7 +3665,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Direction of sort.</span
@@ -4229,7 +3936,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for reference table queries.</span>
@@ -4446,7 +4153,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Aggregation methods for event platform queries.</span>
@@ -4474,7 +4181,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>A time interval in milliseconds.</span>
@@ -4541,7 +4248,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for event platform-based queries.</span>
@@ -4632,7 +4339,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Number of groups to return.</span>
@@ -4696,7 +4403,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -4744,7 +4451,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Direction of sort.</span
@@ -4925,7 +4632,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Aggregator for metrics queries.</span>
@@ -4956,7 +4663,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for metrics queries.</span>
@@ -5066,7 +4773,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Aggregation methods for event platform queries.</span>
@@ -5094,7 +4801,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>A time interval in milliseconds.</span>
@@ -5161,7 +4868,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Data source for aggregate augmented queries.</span>
@@ -5246,7 +4953,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Number of groups to return.</span>
@@ -5310,7 +5017,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Aggregation methods for event platform queries.</span>
@@ -5358,7 +5065,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Direction of sort.</span
@@ -5474,7 +5181,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Join type for aggregate query join conditions.</span>
@@ -5679,7 +5386,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Aggregation methods for event platform queries.</span>
@@ -5707,7 +5414,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>A time interval in milliseconds.</span>
@@ -5774,7 +5481,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for event platform-based queries.</span>
@@ -5865,7 +5572,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Number of groups to return.</span>
@@ -5929,7 +5636,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -5977,7 +5684,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Direction of sort.</span
@@ -6158,7 +5865,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Aggregator for metrics queries.</span>
@@ -6189,7 +5896,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for metrics queries.</span>
@@ -6296,7 +6003,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Aggregation methods for event platform queries.</span>
@@ -6324,7 +6031,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>A time interval in milliseconds.</span>
@@ -6391,7 +6098,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Data source for aggregate filtered queries.</span>
@@ -6544,7 +6251,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Aggregation methods for event platform queries.</span>
@@ -6572,7 +6279,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>A time interval in milliseconds.</span>
@@ -6639,7 +6346,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for event platform-based queries.</span>
@@ -6730,7 +6437,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Number of groups to return.</span>
@@ -6794,7 +6501,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -6842,7 +6549,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Direction of sort.</span
@@ -7113,7 +6820,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Data source for reference table queries.</span>
@@ -7371,7 +7078,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Number of groups to return.</span>
@@ -7435,7 +7142,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Aggregation methods for event platform queries.</span>
@@ -7483,7 +7190,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>Direction of sort.</span
@@ -7520,26 +7227,6 @@
                         </div>
                       </div>
                     </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="overall_state"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">overall_state</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>The different states your monitor can be in.</span>
-                        <div class="schema-table__enum _schema-table__enum_d7636a">
-                          Allowed enum values: <code>Alert, Ignored, No Data, OK, Skipped, Unknown, Warn</code>
-                        </div>
-                      </div>
-                    </div>
                     <div class="schema-table__row _schema-table__row_d7636a" data-field-name="priority" data-depth="0">
                       <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
                         <span class="schema-table__name-group _schema-table__name-group_d7636a"
@@ -7547,7 +7234,7 @@
                         >
                       </div>
                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                        <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                       </div>
                       <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                         <span>Integer from 1 (high) to 5 (low) indicating alert severity.</span>
@@ -7596,53 +7283,6 @@
                         >
                       </div>
                     </div>
-                    <div
-                      class="schema-table__row _schema-table__row_d7636a schema-table__row--readonly _schema-table__row--readonly_d7636a"
-                      data-field-name="state"
-                      data-depth="0"
-                    >
-                      <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
-                        <button
-                          type="button"
-                          class="schema-table__toggle _schema-table__toggle_d7636a"
-                          aria-expanded="false"
-                          aria-label="Toggle state"
-                        >
-                          <svg class="expand-chevron" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-                            <path d="M3 1 L7 5 L3 9" fill="none" stroke="currentColor" stroke-width="1.5"></path>
-                          </svg></button
-                        ><span class="schema-table__name-group _schema-table__name-group_d7636a"
-                          ><code class="schema-table__name _schema-table__name_d7636a">state</code></span
-                        >
-                      </div>
-                      <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">object</span>
-                      </div>
-                      <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                        <span>Wrapper object with the different monitor states.</span>
-                      </div>
-                    </div>
-                    <div class="schema-table__children _schema-table__children_d7636a" hidden>
-                      <div class="schema-table__row _schema-table__row_d7636a" data-field-name="groups" data-depth="1">
-                        <div
-                          class="schema-table__cell-name _schema-table__cell-name_d7636a"
-                          style="padding-left: calc(var(--space-md) + 20px)"
-                        >
-                          <span class="schema-table__name-group _schema-table__name-group_d7636a"
-                            ><code class="schema-table__name _schema-table__name_d7636a">groups</code></span
-                          >
-                        </div>
-                        <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                          <span class="schema-table__type _schema-table__type_d7636a">object</span>
-                        </div>
-                        <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
-                          <span
-                            >Dictionary where the keys are groups (comma separated lists of tags) and the values are the
-                            list of groups your monitor is broken down on.</span
-                          >
-                        </div>
-                      </div>
-                    </div>
                     <div class="schema-table__row _schema-table__row_d7636a" data-field-name="tags" data-depth="0">
                       <div class="schema-table__cell-name _schema-table__cell-name_d7636a">
                         <span class="schema-table__name-group _schema-table__name-group_d7636a"
@@ -7664,7 +7304,7 @@
                         >
                       </div>
                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                       </div>
                       <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                         <span
@@ -7910,7 +7550,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Indicates the type of asset this entity represents on a monitor.</span>
@@ -7981,7 +7621,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Type of internal Datadog resource associated with a monitor asset.</span>
@@ -8029,7 +7669,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Timestamp of the monitor creation.</span>
@@ -8140,7 +7780,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Whether or not the monitor is deleted. (Always <code>null</code>)</span>
@@ -8157,7 +7797,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span
@@ -8186,7 +7826,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>ID of this monitor.</span>
@@ -8241,7 +7881,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>POSIX timestamp to end the downtime.</span>
@@ -8264,7 +7904,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>The downtime ID.</span>
@@ -8310,7 +7950,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>POSIX timestamp to start the downtime.</span>
@@ -8345,7 +7985,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Last timestamp when the monitor was edited.</span>
@@ -8634,7 +8274,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -8771,7 +8411,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -8798,7 +8438,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -8829,7 +8469,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -8855,7 +8495,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <strong class="schema-table__deprecated-label _schema-table__deprecated-label_d7636a"
@@ -8885,7 +8525,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -8912,7 +8552,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Toggles the display of additional content sent in the monitor notification.</span
@@ -9024,7 +8664,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -9058,7 +8698,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -9085,7 +8725,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -9431,7 +9071,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int32)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int32</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span
@@ -9456,7 +9096,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">integer (int32)</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">int32</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span
@@ -9684,7 +9324,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor <code>CRITICAL</code> threshold.</span>
@@ -9706,7 +9346,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor <code>CRITICAL</code> recovery threshold.</span>
@@ -9726,7 +9366,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor <code>OK</code> threshold.</span>
@@ -9746,7 +9386,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor UNKNOWN threshold.</span>
@@ -9766,7 +9406,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor <code>WARNING</code> threshold.</span>
@@ -9788,7 +9428,7 @@
                                   >
                                 </div>
                                 <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                  <span class="schema-table__type _schema-table__type_d7636a">number (double)</span>
+                                  <span class="schema-table__type _schema-table__type_d7636a">double</span>
                                 </div>
                                 <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                   <span>The monitor <code>WARNING</code> recovery threshold.</span>
@@ -9809,7 +9449,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span
@@ -9967,7 +9607,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -9997,7 +9637,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>A time interval in milliseconds.</span>
@@ -10064,7 +9704,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Data source for event platform-based queries.</span>
@@ -10155,7 +9795,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Number of groups to return.</span>
@@ -10219,7 +9859,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10279,7 +9919,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -10464,7 +10104,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Aggregation methods for metric queries.</span>
@@ -10491,7 +10131,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Data source for cost queries.</span>
@@ -10605,7 +10245,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Data source for data quality queries.</span>
@@ -10836,7 +10476,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Override for the model type used in anomaly detection.</span>
@@ -11114,7 +10754,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11150,9 +10790,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11229,7 +10867,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11330,9 +10968,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11403,7 +11039,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11464,7 +11100,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11759,7 +11395,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -11997,7 +11633,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12033,9 +11669,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12112,7 +11746,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12213,9 +11847,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12286,7 +11918,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12347,7 +11979,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12546,7 +12178,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12581,7 +12213,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -12702,7 +12334,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -12732,7 +12364,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>A time interval in milliseconds.</span>
@@ -12799,7 +12431,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Data source for aggregate augmented queries.</span>
@@ -12889,7 +12521,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Number of groups to return.</span>
@@ -12953,7 +12585,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13013,7 +12645,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13138,7 +12770,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Join type for aggregate query join conditions.</span>
@@ -13367,7 +12999,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13403,9 +13035,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13482,7 +13112,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13583,9 +13213,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13656,7 +13284,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13717,7 +13345,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13916,7 +13544,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -13951,7 +13579,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14069,7 +13697,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Aggregation methods for event platform queries.</span>
@@ -14099,7 +13727,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>A time interval in milliseconds.</span>
@@ -14166,7 +13794,7 @@
                                     >
                                   </div>
                                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                    <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                   </div>
                                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                     <span>Data source for aggregate filtered queries.</span>
@@ -14329,7 +13957,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                          <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14365,9 +13993,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14444,7 +14070,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14545,9 +14171,7 @@
                                           >
                                         </div>
                                         <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                          <span class="schema-table__type _schema-table__type_d7636a"
-                                            >integer (int64)</span
-                                          >
+                                          <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                         </div>
                                         <div
                                           class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14618,7 +14242,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14679,7 +14303,7 @@
                                             >
                                           </div>
                                           <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                            <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                            <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                           </div>
                                           <div
                                             class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -14974,7 +14598,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -15254,7 +14878,7 @@
                                       >
                                     </div>
                                     <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                      <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                      <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                                     </div>
                                     <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                       <span>Number of groups to return.</span>
@@ -15318,7 +14942,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -15378,7 +15002,7 @@
                                         >
                                       </div>
                                       <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                        <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                                        <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                                       </div>
                                       <div
                                         class="schema-table__cell-description _schema-table__cell-description_d7636a"
@@ -15428,7 +15052,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>The different states your monitor can be in.</span>
@@ -15448,7 +15072,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span>Integer from 1 (high) to 5 (low) indicating alert severity.</span>
@@ -15593,7 +15217,7 @@
                               >
                             </div>
                             <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                              <span class="schema-table__type _schema-table__type_d7636a">string</span>
+                              <span class="schema-table__type _schema-table__type_d7636a">enum</span>
                             </div>
                             <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                               <span

--- a/astro/tests/headless/api-html-snapshots/10-dashboard-lists-get-all-dashboard-lists.html
+++ b/astro/tests/headless/api-html-snapshots/10-dashboard-lists-get-all-dashboard-lists.html
@@ -476,7 +476,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Date of creation of the dashboard list.</span>
@@ -498,7 +498,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>The number of dashboards in the list.</span>
@@ -518,7 +518,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">integer (int64)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">int64</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>The ID of the dashboard list.</span>
@@ -558,7 +558,7 @@
                                 >
                               </div>
                               <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                                <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                                <span class="schema-table__type _schema-table__type_d7636a">date-time</span>
                               </div>
                               <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                                 <span>Date of last edition of the dashboard list.</span>

--- a/astro/tests/headless/api-html-snapshots/12-usage-metering-get-hourly-usage-for-lambda.html
+++ b/astro/tests/headless/api-html-snapshots/12-usage-metering-get-hourly-usage-for-lambda.html
@@ -252,7 +252,7 @@
                     >
                   </div>
                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                    <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
                   </div>
                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                     <span
@@ -268,7 +268,7 @@
                     >
                   </div>
                   <div class="schema-table__cell-type _schema-table__cell-type_d7636a">
-                    <span class="schema-table__type _schema-table__type_d7636a">string (date-time)</span>
+                    <span class="schema-table__type _schema-table__type_d7636a">string</span>
                   </div>
                   <div class="schema-table__cell-description _schema-table__cell-description_d7636a">
                     <span

--- a/astro/tests/integration/refResolver.full-spec.test.ts
+++ b/astro/tests/integration/refResolver.full-spec.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Invariants the type column depends on, checked against the full live spec.
+ *
+ * `displayType` reports a schema's `format` in place of its `type`, matching
+ * Hugo's `format || type`. That is only lossless while every format implies
+ * exactly one base type — `int64` means integer, `date-time` means string.
+ * OpenAPI defines the built-in formats that way, but a vendor format added to
+ * the spec later could break it, at which point the type column would start
+ * hiding information. This file fails loudly if that happens.
+ *
+ * Picked up by `vitest.integration.config.ts`, which omits the frozen-fixture
+ * plugin so `@hugo-site/data/api` resolves to the real Hugo data directory.
+ */
+
+import { describe, it, expect } from "vitest";
+import { API_VERSIONS, getOpenApiDocument } from "@lib/api/specParser";
+
+/** Walk every schema object in a spec, guarding against shared/cyclic nodes. */
+function eachSchema(root: unknown, visit: (node: Record<string, unknown>) => void) {
+  const seen = new Set<unknown>();
+  const walk = (node: unknown, depth: number) => {
+    if (!node || typeof node !== "object" || depth > 14 || seen.has(node)) return;
+    seen.add(node);
+    if (!Array.isArray(node)) visit(node as Record<string, unknown>);
+    for (const value of Object.values(node)) walk(value, depth + 1);
+  };
+  walk(root, 0);
+}
+
+describe("type column invariants across the full spec", () => {
+  it("every format implies exactly one base type", () => {
+    const byFormat = new Map<string, Set<string>>();
+
+    for (const version of API_VERSIONS) {
+      const spec = getOpenApiDocument(version) as unknown as Record<string, unknown>;
+      eachSchema((spec.components as Record<string, unknown>)?.schemas, (node) => {
+        if (typeof node.format !== "string") return;
+        const base = typeof node.type === "string" ? node.type : "(no type)";
+        const types = byFormat.get(node.format) ?? new Set<string>();
+        types.add(base);
+        byFormat.set(node.format, types);
+      });
+    }
+
+    // Sanity check that the walk found the formats we know are in the spec,
+    // so an empty result can't pass this test silently.
+    expect(byFormat.has("int64")).toBe(true);
+    expect(byFormat.has("date-time")).toBe(true);
+
+    const ambiguous = [...byFormat.entries()]
+      .filter(([, types]) => types.size > 1)
+      .map(([format, types]) => `${format} → ${[...types].sort().join(", ")}`);
+
+    expect(
+      ambiguous,
+      "displayType reports `format` instead of `type`, which assumes each " +
+        "format has one base type. These formats now appear with several, so " +
+        "the type column would hide the base type. Either qualify these in " +
+        "`displayType` or align the spec.",
+    ).toEqual([]);
+  });
+
+  it("no schema carries a format without a type", () => {
+    const orphans: string[] = [];
+
+    for (const version of API_VERSIONS) {
+      const spec = getOpenApiDocument(version) as unknown as Record<string, unknown>;
+      eachSchema((spec.components as Record<string, unknown>)?.schemas, (node) => {
+        if (typeof node.format === "string" && typeof node.type !== "string") {
+          orphans.push(`${version}: format "${node.format}" with no type`);
+        }
+      });
+    }
+
+    // A format with no type would render as the format alone with nothing to
+    // fall back to, so the base type has to come from somewhere.
+    expect(orphans).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

1. Brings the `astro/` API schema tables in line with the `hugo` implementation.
2. adds a line to the `astro/README.md` on how to install `ask-ai` `astro/` dependency

**motivation**: https://datadoghq.atlassian.net/jira/people/5fd13b2734847e0069ea3ec5/boards/18030?selectedIssue=WEB-10078

### Pages to check visually

See jira card for additional links. 

| # | Page | Path | Expected |
| - | ---- | ---- | -------- |
| 1 | http://localhost:4321/api/latest/aws-integration/set-an-aws-tag-filter/ | Request Body | `namespace` → `enum`, with `account_id` and `tag_filter_str` still `string` |
| 2 | http://localhost:4321/api/latest/security-monitoring/add-a-security-signal-to-an-incident/ | Request Body | `incident_id` and `version` → `int64`, with `add_to_signal_timeline` still `boolean` |
| 3 | http://localhost:4321/api/latest/dashboard-lists/get-a-dashboard-list/ | — | path parameter `list_id` → `integer`, while in the Response `id` → `int64` and `created`/`modified` → `date-time` |
| 4 | http://localhost:4321/api/latest/synthetics/create-a-test/ | Request Body → `config` → `assertions` → `Object 1` → `target` | `Object 1` → `double`, `Object 2` → `string` (previously both `object`) |

**NOTE**: The 4th page shows an additional fix not mentioned on the jira card for nested `oneOf` fields. 

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude investigated the differences against the Hugo implementation, wrote the fixes and the tests, and ran the cross-site comparisons. I reviewed the result.

### Additional notes

Two changes in this branch are unrelated to WEB-10078: a README line documenting the shared Ask AI package install command, and a path correction in `astro/src/lib/site/websitesModulesPath.ts`.

One Hugo rule is deliberately not reproduced: `isReadOnlyRow` also treats an array as read-only when `items.readOnly` is true even when the array itself is not marked. Astro reads `readOnly` only from the array schema. Whether that shape occurs in these specs is unverified.