### PR TITLE
[DOCS-14545] Document dynamic installation rule evaluation for AWS Agent install

### DIFF
--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -1,6 +1,6 @@
 ---
 title: How Agent Installation through the AWS Integration Works
-description: "Understand how Datadog installs and maintains the Datadog Agent on Amazon EC2 through the AWS integration: the AWS resources created, the installation mechanism, the security model, and the Agent lifecycle."
+description: "Understand how Datadog installs and maintains the Datadog Agent on Amazon EC2 through the AWS integration: the AWS resources created, the installation mechanism, the security model, and the Agent life cycle."
 private: true # TODO(DOCS-14545): remove at v1 rollout to publish, at the same time as the setup guide this page links to; also add the nextlink entry under "AWS guides" in hugo/content/en/integrations/guide/_index.md at that time
 further_reading:
 - link: "https://docs.datadoghq.com/integrations/guide/aws-agent-installation/"
@@ -44,7 +44,7 @@ Datadog does not create S3 buckets, event buses, log groups, or SSM parameters, 
 
 ## How Agent installation works
 
-After you save an installation rule, Datadog resolves the query you defined into the set of covered instances, and re-resolves it over time. Datadog runs the following sequence against each covered instance. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
+After you save an installation rule, Datadog finds the instances that match it, and keeps checking for new matches over time. Datadog runs the following sequence against each covered instance. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
 
 1. Datadog checks that each covered instance is running, on a supported platform, and reachable by AWS Systems Manager.
 2. When an instance has no IAM instance profile, Datadog creates one so Systems Manager can reach it. When an instance already has one, Datadog adds the SSM policy and the scoped secret-read policy to the existing role.
@@ -88,13 +88,13 @@ The API key is stored in your own Secrets Manager, encrypted at rest. Only the s
 - Datadog tracks which instances it installed an Agent on, so it cleans up only its own work.
 - When some regions cannot be listed, Datadog skips cleanup for that pass rather than risk uninstalling in bulk.
 
-## Agent lifecycle and reconciliation
+## Agent life cycle and coverage
 
 ### Rule coverage is evaluated over time
 
-A rule covers whichever instances match its query, and Datadog re-resolves that query against your current fleet on an ongoing basis. An instance that starts matching later, because it was launched after you saved the rule or because its tags changed, is instrumented automatically. Datadog does not instrument anything outside the query.
+A rule covers whichever instances match it, and Datadog keeps checking the rule against your instances over time. An instance that starts matching later, because it was launched after you saved the rule or because its tags changed, is instrumented automatically. Datadog does not instrument anything the rule does not match.
 
-To pin coverage to a fixed set of instances, select those instances individually. The rule then matches the instances you picked and nothing else, so re-evaluation never widens it.
+To pin coverage to a fixed set of instances, select those instances individually. The rule then matches the instances you picked and nothing else, so later checks never add to it.
 
 When a fixed set is too large to pick by hand, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
 
@@ -102,28 +102,29 @@ When a fixed set is too large to pick by hand, match a tag you control, such as 
 
 Datadog continuously maintains the state you define on the covered instances:
 
-- A full reconciliation runs hourly per AWS account. Reconciliation re-resolves each rule and installs the Agent on instances that have started matching. It also reinstalls the Agent if it goes missing, retries anything that failed, and cleans up instances that no longer exist.
-- Already-installed instances are re-verified about once per day rather than every hour, to avoid unnecessary activity.
-- Change events from the CloudFormation stack let Datadog react to covered instances within minutes, instead of waiting for the hourly pass.
+- Datadog checks your rules regularly, and instruments instances that have started matching.
+- Datadog reinstalls the Agent if it goes missing, retries failed installs, and cleans up instances that no longer exist.
+- New matches are usually instrumented within an hour, and often within minutes.
+- Instances that already have the Agent are checked less often.
 
 ### What happens when coverage changes
 
-Whenever Datadog re-resolves a rule, either because you edited it or as part of ongoing evaluation, it compares the result against the previous set. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
+When coverage changes, Datadog compares the current matches against the previous ones. Coverage changes when you edit the rule, and when your instances change. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
 
 <div class="alert alert-warning">
-Uninstalls are triggered by the rule no longer matching, not only by an edit in Datadog. Retagging or reconfiguring an instance in AWS so that it falls outside the query removes the Agent on the next evaluation. Take this into account when you write a rule against tags that other teams change.
+Uninstalls are triggered by the rule no longer matching, not only by an edit in Datadog. Retagging or reconfiguring an instance in AWS so that it no longer matches removes the Agent from it. Take this into account when you write a rule against tags that other teams change.
 </div>
 
 ### Terminated or stopped instances
 
-Datadog detects terminated instances on the next hourly pass and cleans up the IAM resources it created for them. Datadog leaves stopped instances alone until they return.
+Datadog detects terminated instances and cleans up the IAM resources it created for them. Datadog leaves stopped instances alone until they return.
 
 ### When an install fails
 
 Datadog retries with an increasing delay (1 hour, then 2 hours, up to once per day) and continues retrying. Missing-permission problems appear as an issue on the **AWS integration tile** and on the Fleet install page.
 
 <div class="alert alert-warning">
-When someone manually removes the Agent from a covered instance, the next reconciliation reinstalls it. The rule is the source of truth. To stop coverage, change the rule so that the instance no longer matches it.
+When someone manually removes the Agent from a covered instance, Datadog reinstalls it. The rule is the source of truth. To stop coverage, change the rule so that the instance no longer matches it.
 </div>
 
 ## Uninstall the Agent

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -108,6 +108,10 @@ Datadog continuously maintains the state you define on the covered instances:
 
 Whenever Datadog re-resolves a rule, either because you edited it or as part of ongoing evaluation, it compares the result against the previous set. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
 
+<div class="alert alert-warning">
+Uninstalls are triggered by the rule no longer matching, not only by an edit in Datadog. Retagging or reconfiguring an instance in AWS so that it falls outside the query removes the Agent on the next evaluation. Take this into account when you write a rule against tags that other teams change.
+</div>
+
 ### Terminated or stopped instances
 
 Datadog detects terminated instances on the next hourly pass and cleans up the IAM resources it created for them. Datadog leaves stopped instances alone until they return.

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -44,7 +44,7 @@ Datadog does not create S3 buckets, event buses, log groups, or SSM parameters, 
 
 ## How Agent installation works
 
-After you save an installation rule, Datadog finds the instances that match it, and keeps checking for new matches over time. Datadog runs the following sequence against each covered instance. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
+After you save an installation rule, Datadog finds the instances that match it and keeps checking for new matches over time. Datadog runs the following sequence against each covered instance. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
 
 1. Datadog checks that each covered instance is running, on a supported platform, and reachable by AWS Systems Manager.
 2. When an instance has no IAM instance profile, Datadog creates one so Systems Manager can reach it. When an instance already has one, Datadog adds the SSM policy and the scoped secret-read policy to the existing role.
@@ -92,27 +92,27 @@ The API key is stored in your own Secrets Manager, encrypted at rest. Only the s
 
 ### Rule coverage is evaluated over time
 
-A rule covers whichever instances match it, and Datadog keeps checking the rule against your instances over time. An instance that starts matching later, because it was launched after you saved the rule or because its tags changed, is instrumented automatically. Datadog does not instrument anything the rule does not match.
+A rule covers instances that match it, and Datadog checks for new matches over time. If an instance starts matching later because it was launched after you saved the rule or because its tags changed, Datadog instruments it automatically. Datadog does not instrument instances that the rule does not match.
 
-To pin coverage to a fixed set of instances, select those instances individually. The rule then matches the instances you picked and nothing else, so later checks never add to it.
+To pin coverage to a fixed set of instances, select those instances individually. The rule then matches only the instances you selected, so later checks do not add new instances.
 
-When a fixed set is too large to pick by hand, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
+When a fixed set is too large to select individually, match on a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
 
 ### How Datadog keeps covered instances in sync
 
 Datadog continuously maintains the state you define on the covered instances:
 
-- Datadog checks your rules regularly, and instruments instances that have started matching.
+- Datadog checks your rules regularly and instruments instances that match.
 - Datadog reinstalls the Agent if it goes missing, retries failed installs, and cleans up instances that no longer exist.
 - New matches are usually instrumented within an hour, and often within minutes.
 - Instances that already have the Agent are checked less often.
 
 ### What happens when coverage changes
 
-When coverage changes, Datadog compares the current matches against the previous ones. Coverage changes when you edit the rule, and when your instances change. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
+When coverage changes, Datadog determines which instances were added to or removed from the rule's coverage. Coverage changes when you edit the rule or when your instances change. Datadog installs the Agent on newly covered instances and uninstalls it from instances that are no longer covered. Deleting a rule uninstalls the Agent from all instances the rule covered.
 
 <div class="alert alert-warning">
-Uninstalls are triggered by the rule no longer matching, not only by an edit in Datadog. Retagging or reconfiguring an instance in AWS so that it no longer matches removes the Agent from it. Take this into account when you write a rule against tags that other teams change.
+Datadog uninstalls the Agent when an instance no longer matches the rule, whether the change comes from an edit in Datadog or from retagging or reconfiguring the instance in AWS. Keep this behavior in mind when you write a rule based on tags that other teams can change.
 </div>
 
 ### Terminated or stopped instances

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -94,7 +94,9 @@ The API key is stored in your own Secrets Manager, encrypted at rest. Only the s
 
 A rule covers whichever instances match its query, and Datadog re-resolves that query against your current fleet on an ongoing basis. An instance that starts matching later, because it was launched after you saved the rule or because its tags changed, is instrumented automatically. Datadog does not instrument anything outside the query.
 
-To pin coverage to a fixed set of instances, write a rule that matches a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
+To pin coverage to a fixed set of instances, select those instances individually. The rule then matches the instances you picked and nothing else, so re-evaluation never widens it.
+
+When a fixed set is too large to pick by hand, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
 
 ### How Datadog keeps covered instances in sync
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation-technical-reference.md
@@ -44,7 +44,7 @@ Datadog does not create S3 buckets, event buses, log groups, or SSM parameters, 
 
 ## How Agent installation works
 
-After you save an installation rule, Datadog resolves the query you defined into a fixed list of covered instances. Datadog then runs the following sequence against each one. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
+After you save an installation rule, Datadog resolves the query you defined into the set of covered instances, and re-resolves it over time. Datadog runs the following sequence against each covered instance. For prerequisites, including supported platforms, see [Prerequisites][2] in the setup guide.
 
 1. Datadog checks that each covered instance is running, on a supported platform, and reachable by AWS Systems Manager.
 2. When an instance has no IAM instance profile, Datadog creates one so Systems Manager can reach it. When an instance already has one, Datadog adds the SSM policy and the scoped secret-read policy to the existing role.
@@ -90,21 +90,23 @@ The API key is stored in your own Secrets Manager, encrypted at rest. Only the s
 
 ## Agent lifecycle and reconciliation
 
-### Rule coverage is fixed at save time
+### Rule coverage is evaluated over time
 
-A rule covers the list of instances it resolved to when you saved it, and Datadog does not instrument anything outside that list. Instances launched later are not picked up automatically. To cover them, update the rule, which re-resolves your query against your current fleet.
+A rule covers whichever instances match its query, and Datadog re-resolves that query against your current fleet on an ongoing basis. An instance that starts matching later, because it was launched after you saved the rule or because its tags changed, is instrumented automatically. Datadog does not instrument anything outside the query.
+
+To pin coverage to a fixed set of instances, write a rule that matches a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags.
 
 ### How Datadog keeps covered instances in sync
 
 Datadog continuously maintains the state you define on the covered instances:
 
-- A full reconciliation runs hourly per AWS account. Reconciliation reinstalls the Agent if it goes missing, retries anything that failed, and cleans up instances that no longer exist.
+- A full reconciliation runs hourly per AWS account. Reconciliation re-resolves each rule and installs the Agent on instances that have started matching. It also reinstalls the Agent if it goes missing, retries anything that failed, and cleans up instances that no longer exist.
 - Already-installed instances are re-verified about once per day rather than every hour, to avoid unnecessary activity.
 - Change events from the CloudFormation stack let Datadog react to covered instances within minutes, instead of waiting for the hourly pass.
 
-### What happens when you edit a rule
+### What happens when coverage changes
 
-Datadog re-resolves your query and compares it against the previous list. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
+Whenever Datadog re-resolves a rule, either because you edited it or as part of ongoing evaluation, it compares the result against the previous set. Instances no longer covered have the Agent uninstalled. Newly covered instances have the Agent installed. Deleting a rule uninstalls the Agent from everything the rule covered.
 
 ### Terminated or stopped instances
 
@@ -115,12 +117,12 @@ Datadog detects terminated instances on the next hourly pass and cleans up the I
 Datadog retries with an increasing delay (1 hour, then 2 hours, up to once per day) and continues retrying. Missing-permission problems appear as an issue on the **AWS integration tile** and on the Fleet install page.
 
 <div class="alert alert-warning">
-When someone manually removes the Agent from a covered instance, the next reconciliation reinstalls it. The rule is the source of truth. To stop coverage, change the rule.
+When someone manually removes the Agent from a covered instance, the next reconciliation reinstalls it. The rule is the source of truth. To stop coverage, change the rule so that the instance no longer matches it.
 </div>
 
 ## Uninstall the Agent
 
-Uninstalling removes the Datadog Agent, the `/etc/datadog-agent` and `/opt/datadog-agent` directories on Linux (or performs an MSI uninstall on Windows), and any IAM role or instance profile Datadog created for that instance. To uninstall, remove instances from a rule, edit the rule's query, or delete the rule.
+Uninstalling removes the Datadog Agent, the `/etc/datadog-agent` and `/opt/datadog-agent` directories on Linux (or performs an MSI uninstall on Windows), and any IAM role or instance profile Datadog created for that instance. To uninstall, edit the rule's query so the instances no longer match, remove instances from a rule, or delete the rule.
 
 ## Further reading
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -82,6 +82,10 @@ Because Datadog re-checks the rule over time, the query you write determines how
 
 **To cover a fixed set**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, which keeps the decision in your own infrastructure-as-code.
 
+<div class="alert alert-warning">
+Coverage works in both directions. When an instance stops matching the rule, Datadog uninstalls the Agent from it. A tag change made in AWS can therefore remove monitoring from an instance without anyone editing the rule in Datadog.
+</div>
+
 ## Install the Agent
 
 You can start Agent installation from two entry points, depending on how much control you want over which instances are instrumented:

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -88,6 +88,16 @@ Because Datadog re-checks the rule over time, the query you write determines how
 Coverage works in both directions. When an instance stops matching the rule, Datadog uninstalls the Agent from it. A tag change made in AWS can therefore remove monitoring from an instance without anyone editing the rule in Datadog.
 </div>
 
+### Best practices for rules and tags
+
+**Match tags your team owns.** When a rule matches a tag that another team controls, that team can add or remove monitoring by retagging, without opening Datadog. Keeping the tag and the rule under the same ownership keeps that decision with the people who made it.
+
+**Avoid tags that change during normal operations.** Tags that move with an environment promotion, a deployment, or an autoscaling template rewrite instances in and out of coverage each time they change. Match on attributes that stay stable for the life of the instance.
+
+**Treat the rule as the full picture for the account.** Each AWS account has one rule per resource type. Every edit re-scopes all coverage for that resource type at once, rather than adding to what you had. Review the matching instances before you save.
+
+**Carve out exceptions with exclusions.** When a broad rule covers instances you want to skip, exclude them from the same rule instead of switching to a hand-picked list. Exclusions keep the rule readable and preserve automatic coverage for everything else.
+
 ## Install the Agent
 
 You can start Agent installation from two entry points, depending on how much control you want over which instances are instrumented:

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -61,7 +61,7 @@ Datadog uses each of these permissions for a specific task:
 
 ## How it works
 
-Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Datadog re-checks the rule over time and installs the Agent on each matching instance, inside your own account:
+Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Datadog re-checks the rule over time and installs the Agent on each matching instance in your AWS account:
 
 1. You select the EC2 instances to cover, or opt in to all eligible instances.
 1. Datadog identifies the instances your selection covers.
@@ -78,11 +78,11 @@ For the full technical and security details, including the AWS resources Datadog
 
 Because Datadog re-checks the rule over time, the query you write determines how coverage behaves as your infrastructure changes.
 
-**To cover instances as they appear**, match tags and attributes already present in your infrastructure, such as `env:prod`. Any instance that matches is instrumented, including instances launched or retagged after you save the rule. Use this when you want new capacity monitored without revisiting Datadog.
+**To cover instances as they appear**, match tags and attributes already present in your infrastructure, such as `env:prod`. Any instance that matches is instrumented, including instances launched or retagged after you save the rule. Use this when you want new matching instances monitored automatically without updating the rule.
 
-**To cover a fixed set**, select the instances individually from the resource list. The rule matches only the instances you picked, so instances that appear later are not added.
+**To cover a fixed set**, select the instances individually from the resource list. The rule matches only the instances you selected, so instances that appear later are not added.
 
-**When a fixed set is too large to pick by hand**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, which keeps the decision in your own infrastructure-as-code.
+**When a fixed set is too large to select individually**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, so your infrastructure-as-code determines which instances are covered.
 
 <div class="alert alert-warning">
 Coverage works in both directions. When an instance stops matching the rule, Datadog uninstalls the Agent from it. A tag change made in AWS can therefore remove monitoring from an instance without anyone editing the rule in Datadog.
@@ -92,11 +92,11 @@ Coverage works in both directions. When an instance stops matching the rule, Dat
 
 **Match tags your team owns.** When a rule matches a tag that another team controls, that team can add or remove monitoring by retagging, without opening Datadog. Keeping the tag and the rule under the same ownership keeps that decision with the people who made it.
 
-**Avoid tags that change during normal operations.** Tags that move with an environment promotion, a deployment, or an autoscaling template rewrite instances in and out of coverage each time they change. Match on attributes that stay stable for the life of the instance.
+**Avoid tags that change during normal operations.** Tags that change with an environment promotion, a deployment, or an autoscaling template can move instances in and out of coverage. Match on attributes that stay stable for the life of the instance.
 
-**Treat the rule as the full picture for the account.** Each AWS account has one rule per resource type. Every edit re-scopes all coverage for that resource type at once, rather than adding to what you had. Review the matching instances before you save.
+**Treat the rule as the complete configuration for the account.** Each AWS account has one rule per resource type. Every edit re-scopes all coverage for that resource type rather than adding to the existing coverage. Review the matching instances before you save.
 
-**Carve out exceptions with exclusions.** When a broad rule covers instances you want to skip, exclude them from the same rule instead of switching to a hand-picked list. Exclusions keep the rule readable and preserve automatic coverage for everything else.
+**Carve out exceptions with exclusions.** When a broad rule covers instances you want to skip, exclude them from the same rule instead of switching to an individually selected list. Exclusions keep the rule readable and preserve automatic coverage for everything else.
 
 ## Install the Agent
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -64,13 +64,13 @@ Datadog uses each of these permissions for a specific task:
 Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Datadog re-checks the rule over time and installs the Agent on each matching instance, inside your own account:
 
 1. You select the EC2 instances to cover, or opt in to all eligible instances.
-1. Datadog resolves your selection into the set of covered instances.
+1. Datadog identifies the instances your selection covers.
 1. Datadog installs the Agent on each covered instance through AWS Systems Manager, adding any missing IAM configuration automatically.
 1. Datadog re-checks the rule over time. Instances that match it later, whether newly launched or newly tagged, are instrumented automatically.
 
 You approve one CloudFormation stack, one time, during initial setup. After that, installations run automatically from Datadog, with no new CloudFormation template to launch for each installation.
 
-For the full technical and security details, including the AWS resources Datadog creates, the installation mechanism, and the reconciliation model, see [How Agent installation through the AWS integration works][6].
+For the full technical and security details, including the AWS resources Datadog creates, the installation mechanism, and how Datadog keeps instances covered, see [How Agent installation through the AWS integration works][6].
 
 {{< img src="integrations/amazon_web_services/aws-agent-installation-how-it-works.png" alt="Flowchart of the AWS Agent installation process, showing which steps happen in Datadog and which run inside your AWS account." style="width:70%;" >}}
 
@@ -128,7 +128,7 @@ From this page, you can:
 - Install the Agent on new instances in your AWS environment.
 - Uninstall Agents from instances you no longer want to monitor.
 
-To stop coverage, update the rule so that the instances no longer match it. If you manually remove the Agent from a covered instance, Datadog reinstalls it on the next reconciliation. Manage Agent configuration and version upgrades through [Fleet Automation][4].
+To stop coverage, update the rule so that the instances no longer match it. If you manually remove the Agent from a covered instance, Datadog reinstalls it. Manage Agent configuration and version upgrades through [Fleet Automation][4].
 
 ## Troubleshooting
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -61,18 +61,26 @@ Datadog uses each of these permissions for a specific task:
 
 ## How it works
 
-Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Saving a rule resolves the query into a fixed list of instances. Datadog then installs the Agent on each one, inside your own account:
+Agent installation is based on an **installation rule**: an AWS account paired with a query that describes which EC2 instances to cover. Datadog re-checks the rule over time and installs the Agent on each matching instance, inside your own account:
 
 1. You select the EC2 instances to cover, or opt in to all eligible instances.
-1. Datadog resolves your selection into a list of covered instances and records it.
+1. Datadog resolves your selection into the set of covered instances.
 1. Datadog installs the Agent on each covered instance through AWS Systems Manager, adding any missing IAM configuration automatically.
-1. Datadog keeps the covered instances instrumented. Instances launched later aren't added until you update the rule.
+1. Datadog re-checks the rule over time. Instances that match it later, whether newly launched or newly tagged, are instrumented automatically.
 
 You approve one CloudFormation stack, one time, during initial setup. After that, installations run automatically from Datadog, with no new CloudFormation template to launch for each installation.
 
 For the full technical and security details, including the AWS resources Datadog creates, the installation mechanism, and the reconciliation model, see [How Agent installation through the AWS integration works][6].
 
 {{< img src="integrations/amazon_web_services/aws-agent-installation-how-it-works.png" alt="Flowchart of the AWS Agent installation process, showing which steps happen in Datadog and which run inside your AWS account." style="width:70%;" >}}
+
+### Choose how your rule matches instances
+
+Because Datadog re-checks the rule over time, the query you write determines how coverage behaves as your infrastructure changes.
+
+**To cover instances as they appear**, match tags and attributes already present in your infrastructure, such as `env:prod`. Any instance that matches is instrumented, including instances launched or retagged after you save the rule. Use this when you want new capacity monitored without revisiting Datadog.
+
+**To cover a fixed set**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, which keeps the decision in your own infrastructure-as-code.
 
 ## Install the Agent
 
@@ -114,7 +122,7 @@ From this page, you can:
 - Install the Agent on new instances in your AWS environment.
 - Uninstall Agents from instances you no longer want to monitor.
 
-To stop coverage, update the rule. If you manually remove the Agent from a covered instance, Datadog reinstalls it on the next reconciliation. Manage Agent configuration and version upgrades through [Fleet Automation][4].
+To stop coverage, update the rule so that the instances no longer match it. If you manually remove the Agent from a covered instance, Datadog reinstalls it on the next reconciliation. Manage Agent configuration and version upgrades through [Fleet Automation][4].
 
 ## Troubleshooting
 

--- a/hugo/content/en/integrations/guide/aws-agent-installation.md
+++ b/hugo/content/en/integrations/guide/aws-agent-installation.md
@@ -80,7 +80,9 @@ Because Datadog re-checks the rule over time, the query you write determines how
 
 **To cover instances as they appear**, match tags and attributes already present in your infrastructure, such as `env:prod`. Any instance that matches is instrumented, including instances launched or retagged after you save the rule. Use this when you want new capacity monitored without revisiting Datadog.
 
-**To cover a fixed set**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, which keeps the decision in your own infrastructure-as-code.
+**To cover a fixed set**, select the instances individually from the resource list. The rule matches only the instances you picked, so instances that appear later are not added.
+
+**When a fixed set is too large to pick by hand**, match a tag you control, such as `datadog:true`. Apply that tag only to the instances you want instrumented. Coverage then changes only when you change the tags, which keeps the decision in your own infrastructure-as-code.
 
 <div class="alert alert-warning">
 Coverage works in both directions. When an instance stops matching the rule, Datadog uninstalls the Agent from it. A tag change made in AWS can therefore remove monitoring from an instance without anyone editing the rule in Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-14545

The AWS Agent installation guides describe installation rules as frozen at save time: the set of covered EC2 instances is resolved once, and instances launched later aren't picked up until you edit the rule. Rules are moving to continuous evaluation, so instances that match later — whether newly launched or newly tagged — are instrumented automatically.

This updates both guides to describe that behavior, and adds guidance on the two ways to write a rule: match tags already present in your infrastructure for coverage that grows with your fleet, or match a tag you control for a fixed set.

Dynamic evaluation is the behavior going forward, so these pages no longer document the frozen model.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Claude Code drafted the copy changes from a design discussion and ran Vale.

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

