### PR TITLE
Document Go agentless Feature Flags telemetry

### DIFF
--- a/hugo/content/en/feature_flags/implementation_patterns/serverless.md
+++ b/hugo/content/en/feature_flags/implementation_patterns/serverless.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-The Datadog Feature Flags Java, Node.js, and Python SDKs can receive flag configuration directly from the Datadog-managed CDN. This _agentless_ configuration source simplifies onboarding because it does not require a Datadog Agent for flag configuration. It also supports serverless applications that cannot connect to a Datadog Agent.
+The Datadog Feature Flags Go, Java, Node.js, and Python SDKs can receive flag configuration directly from the Datadog-managed CDN. This _agentless_ configuration source simplifies onboarding because it does not require a Datadog Agent for flag configuration. It also supports serverless applications that cannot connect to a Datadog Agent.
 
 After configuration is loaded, flag evaluation happens locally in the application. The SDK does not make a network request for each evaluation.
 
@@ -26,6 +26,7 @@ The following table shows the Feature Flags functionality available in each SDK 
 
 | SDK | Minimum version | Agentless configuration and local evaluation | Experiment exposure events | Event Platform Proxy (EVP) flag evaluation events | Event delivery |
 |---|---|---|---|---|---|
+| Go `dd-trace-go` | 2.11.0 | Supported | Supported | Supported | Prefer a compatible local telemetry relay; use direct fallback when unavailable |
 | Java `dd-openfeature` and `dd-java-agent` | 1.66.0 | Supported | Supported | Supported | Prefer a compatible local telemetry relay; use direct fallback when unavailable |
 | Node.js `dd-trace` | 6.12.0 | Supported | Supported | Not supported | Prefer a compatible local telemetry relay; use direct fallback when unavailable |
 | Python `ddtrace` | 4.14.0 | Supported | Supported | Supported | Compatible local telemetry relay |
@@ -49,7 +50,7 @@ Use agentless delivery when the serverless runtime can make outbound HTTPS reque
    DD_SITE={{< region-param key="dd_site" code="true" >}}
    DD_ENV=<YOUR_ENVIRONMENT>{{< /code-block >}}
 
-4. Initialize or access the Datadog OpenFeature provider as described in the [Java][6], [Node.js][3], or [Python][9] setup. This starts CDN polling. No Feature Flags enablement or source setting is required.
+4. Initialize or access the Datadog OpenFeature provider as described in the [Go][12], [Java][6], [Node.js][3], or [Python][9] setup. This starts CDN polling. No Feature Flags enablement or source setting is required.
 5. Store `DD_API_KEY` in the serverless platform's secret manager and expose it only to the application process.
 
 The SDK polls the Datadog-managed CDN every 30 seconds by default and uses ETags for unchanged configuration. It preserves the last accepted configuration during temporary errors. If no configuration has been accepted, OpenFeature evaluations return the caller-provided default value.
@@ -69,8 +70,8 @@ Direct fallback means the SDK sends authenticated EVP events to Datadog when it 
 Note the following behavior:
 
 - Experiment exposure events are emitted only for flags associated with an experiment.
-- Java and Python aggregate EVP flag evaluation events and send them by default.
-- To disable only the EVP flag evaluation event path, set `DD_FLAGGING_EVALUATION_COUNTS_ENABLED=false`.
+- Go, Java, and Python aggregate EVP flag evaluation events and send them by default.
+- For Go, Java, and Python, set `DD_FLAGGING_EVALUATION_COUNTS_ENABLED=false` to disable only the EVP flag evaluation event path.
 
 The `feature_flag.evaluations` metric is a separate OpenTelemetry (OTLP) signal. The standard `serverless-init` connection on port 8126 does not configure the OTLP endpoint for this metric. For no-Agent serverless environments, configure the serverless telemetry path for your platform before you enable this metric. See [Set Up Server-Side Flag Evaluation Metrics][10].
 
@@ -89,7 +90,7 @@ The `feature_flag.evaluations` metric is a separate OpenTelemetry (OTLP) signal.
 1. Initialize the OpenFeature provider and confirm that it reaches a ready state.
 2. Evaluate a flag associated with an experiment, then confirm that the experiment receives an exposure event.
 3. When you use a local relay, check the application and `serverless-init` logs for connection errors to port 8126.
-4. For Java and Python, confirm that `DD_FLAGGING_EVALUATION_COUNTS_ENABLED` is not set to `false` when you need EVP flag evaluation events.
+4. For Go, Java, and Python, confirm that `DD_FLAGGING_EVALUATION_COUNTS_ENABLED` is not set to `false` when you need EVP flag evaluation events.
 5. If you use the `feature_flag.evaluations` metric, validate its separate OTLP path with [Set Up Server-Side Flag Evaluation Metrics][10].
 
 ## Agent-backed Remote Configuration
@@ -181,3 +182,4 @@ Before enabling Feature Flags in production:
 [9]: /feature_flags/server/python/
 [10]: /feature_flags/guide/server_flag_evaluation_metrics/
 [11]: /serverless/
+[12]: /feature_flags/server/go/

--- a/hugo/content/en/feature_flags/server/_index.md
+++ b/hugo/content/en/feature_flags/server/_index.md
@@ -39,13 +39,14 @@ The default source does not activate Feature Flags traffic for every tracer inst
 
 | SDK | Recommended agentless version |
 |---|---|
+| Go `dd-trace-go` | 2.11.0 |
 | Java `dd-openfeature` and `dd-java-agent` | 1.66.0 |
 | Node.js `dd-trace` | 6.12.0 |
 | Python `ddtrace` | 4.14.0 |
 
 Java CDN delivery requires `dd-openfeature` and `dd-java-agent`. It does not require a Datadog Agent for flag configuration.
 
-Agentless delivery changes only the flag configuration source. Java and Node.js support direct exposure delivery. Java, Node.js, and Python can also use a compatible local telemetry relay.
+Agentless delivery changes only the flag configuration source. Go supports direct delivery of both experiment exposure and EVP flag evaluation events when a compatible local telemetry relay is unavailable. Java and Node.js support direct exposure delivery. Go, Java, Node.js, and Python can also use a compatible local telemetry relay.
 
 The listed versions provide the current capabilities described on each language page. Other server SDKs use Agent Remote Configuration.
 

--- a/hugo/content/en/feature_flags/server/go.md
+++ b/hugo/content/en/feature_flags/server/go.md
@@ -21,7 +21,9 @@ further_reading:
 
 ## Overview
 
-This page describes how to instrument your Go application with the Datadog Feature Flags SDK. The Go SDK integrates with [OpenFeature][1], an open standard for feature flag management, and receives flag updates through Remote Configuration in the Datadog Go tracer (`dd-trace-go`).
+This page describes how to instrument your Go application with the Datadog Feature Flags SDK. The Go SDK integrates with [OpenFeature][1], an open standard for feature flag management. Configuration delivery is separate from telemetry delivery: the SDK receives flag updates through either agentless configuration delivery or Agent Remote Configuration in the Datadog Go tracer (`dd-trace-go`).
+
+Beginning with `dd-trace-go` 2.11.0, agentless applications can send both experiment exposure events and aggregated Event Platform Proxy (EVP) flag evaluation events without a Datadog Agent. The SDK uses a compatible local telemetry relay when available. Otherwise, it sends these events directly to Datadog using the application's `DD_API_KEY` and `DD_SITE`.
 
 This guide explains how to install and enable the SDK, create an OpenFeature client, and evaluate feature flags in your application.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9db44503-155a-41ab-9cc0-8bd810160997","source":"chat","resourceId":"ed21815a-ebc1-4eec-ab00-74db3acbd7e3","workflowId":"591308fd-b8f0-46d8-991b-34757c634f54","codeChangeId":"591308fd-b8f0-46d8-991b-34757c634f54","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

The Go Feature Flags documentation describes Agent Remote Configuration but does not show the agentless configuration and telemetry delivery available in `dd-trace-go` 2.11.0. This update helps customers discover how Go applications send Feature Flags events without a Datadog Agent.

The source SDK changes are https://github.com/DataDog/dd-trace-go/pull/5280 and https://github.com/DataDog/dd-trace-go/pull/5346.

#### Changes

- Adds Go 2.11.0 to the agentless SDK capability summaries.
- Documents experiment exposure and aggregated EVP flag evaluation event delivery through a compatible local relay with direct fallback.
- Extends EVP event enablement and verification guidance to Go while keeping configuration and telemetry delivery distinct.

#### Testing

- Ran `git diff --check`.
- Ran the repository pre-commit checks for aliases, generated files, and section indexes.
- Manually reviewed the updated capability tables and Go guidance for consistent terminology and version requirements.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Bits Code powered by Codex CLI to draft and validate the documentation updates.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ed21815a-ebc1-4eec-ab00-74db3acbd7e3)

Comment @datadog to request changes