### PR TITLE
Document Docker support in Bits Code sessions

### DIFF
--- a/hugo/content/en/bits_ai/bits_code/_index.md
+++ b/hugo/content/en/bits_ai/bits_code/_index.md
@@ -90,7 +90,7 @@ You can manually prompt Bits Code to implement changes for a certain finding, or
 
 ### General coding tasks
 
-Use the freeform prompt field at [{{< ui >}}Sessions{{< /ui >}}][7] to work with Bits Code on general coding tasks. Bits Code can use [Docker and Docker Compose][40] to build and test your code within a session.
+Use the freeform prompt field at [{{< ui >}}Sessions{{< /ui >}}][7] to work with Bits Code on general coding tasks.
 
 ### Automations
 
@@ -159,4 +159,3 @@ Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is
 [37]: /source_code/source-code-management#source-code-management-providers
 [38]: https://docs.github.com/en/enterprise-server@3.17/admin/overview/about-github-enterprise-server
 [39]: https://learn.microsoft.com/en-us/azure/devops/?view=azure-devops
-[40]: /bits_ai/bits_code/setup/#use-docker-and-docker-compose

--- a/hugo/content/en/bits_ai/bits_code/_index.md
+++ b/hugo/content/en/bits_ai/bits_code/_index.md
@@ -90,7 +90,7 @@ You can manually prompt Bits Code to implement changes for a certain finding, or
 
 ### General coding tasks
 
-Use the freeform prompt field at [{{< ui >}}Sessions{{< /ui >}}][7] to work with Bits Code on general coding tasks.
+Use the freeform prompt field at [{{< ui >}}Sessions{{< /ui >}}][7] to work with Bits Code on general coding tasks. Bits Code can use [Docker and Docker Compose][40] to build and test your code within a session.
 
 ### Automations
 
@@ -159,3 +159,4 @@ Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is
 [37]: /source_code/source-code-management#source-code-management-providers
 [38]: https://docs.github.com/en/enterprise-server@3.17/admin/overview/about-github-enterprise-server
 [39]: https://learn.microsoft.com/en-us/azure/devops/?view=azure-devops
+[40]: /bits_ai/bits_code/setup/#use-docker-and-docker-compose

--- a/hugo/content/en/bits_ai/bits_code/setup.md
+++ b/hugo/content/en/bits_ai/bits_code/setup.md
@@ -146,6 +146,12 @@ The default allowlist includes the following domains. This list will evolve over
 | Rust | `index.crates.io`, `static.crates.io` |
 | Ubuntu | `archive.ubuntu.com`, `ports.ubuntu.com`, `security.ubuntu.com` |
 
+### Use Docker and Docker Compose
+
+Bits Code sessions support Docker and Docker Compose commands. You can build images and run containers as part of repository setup, testing, and validation.
+
+Access to container registries during a session is controlled by your organization's [internet access](#configure-internet-access) policy.
+
 ### Configure repository environment
 
 Configure a custom environment for Bits Code to install dependencies, formatters, linters, and build tools that are needed for your codebase. Each repository runs in its own isolated sandbox, and the environment defines the settings for that sandbox. 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents that Bits Code sessions support Docker and Docker Compose for building and testing containerized projects. It also explains that container registry access follows the organization internet access policy.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Used Codex to review the existing Bits Code documentation structure, draft the changes, and run Vale.

### Additional notes

Implementation references: [code-gen-backend#7873](https://github.com/DataDog/code-gen-backend/pull/7873) and [code-gen-backend#13010](https://github.com/DataDog/code-gen-backend/pull/13010).