### PR TITLE
[RUM-MCP] Document get_rum_view_waterfall

### DIFF
--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -209,7 +209,7 @@ Search Datadog RUM events using advanced query syntax.
 
 ### `aggregate_rum_events`
 *Toolset: **core**, **rum***\
-*Permissions Required: `RUM Apps Read`*\
+*Permissions Required: `RUM Apps Read` or `Timeseries`*\
 Aggregates RUM events to compute counts, sums, averages, min, max, cardinality, and percentiles, with grouping support. Use this for statistical analysis and trend data, not for inspecting individual events.
 
 - Count JavaScript errors by page in the last 24 hours.
@@ -1587,6 +1587,14 @@ Returns aggregated insights for RUM Views: waterfall, long tasks, vital distribu
 
 - For the `/checkout` view in the "shop" application, show me the aggregated resource waterfall over the last hour.
 - Break down INP distribution by device type for the home page.
+
+### `get_rum_view_waterfall`
+*Toolset: **rum***\
+*Permissions Required: `RUM Apps Read`*\
+Reconstructs the chronological load timeline for a single RUM view occurrence on web or mobile. Returns every resource, long task, error, and user interaction during that view, ordered by start time. Use this to investigate one concrete page load or screen; for the aggregated, cross-session view, use `get_rum_insight`.
+
+- Show the full waterfall for the RUM view with ID `AwAAc3dhcmV`.
+- Why did this specific checkout page load take 12 seconds? Show every request and long task during the view.
 
 ### `search_rum_operations`
 *Toolset: **rum***\

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -1594,7 +1594,7 @@ Returns aggregated insights for RUM Views: waterfall, long tasks, vital distribu
 Reconstructs the chronological load timeline for a single RUM view occurrence on web or mobile. Returns every resource, long task, error, and user interaction during that view, ordered by start time. Use this to investigate one concrete page load or screen; for the aggregated, cross-session view, use `get_rum_insight`.
 
 - Show the full waterfall for the RUM view with ID `AwAAc3dhcmV`.
-- Why did this specific checkout page load take 12 seconds? Show every request and long task during the view.
+- Why did the checkout page load with view UUID `d64b1e7c-8f2a-4c3b-9e1d-5a6b7c8d9e0f` take 12 seconds?
 
 ### `search_rum_operations`
 *Toolset: **rum***\

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -1591,7 +1591,7 @@ Returns aggregated insights for RUM Views: waterfall, long tasks, vital distribu
 ### `get_rum_view_waterfall`
 *Toolset: **rum***\
 *Permissions Required: `RUM Apps Read`*\
-Reconstructs the chronological load timeline for a single RUM view occurrence on web or mobile. Returns every resource, long task, error, and user interaction during that view, ordered by start time. Use this to investigate one concrete page load or screen; for the aggregated, cross-session view, use `get_rum_insight`.
+Reconstructs the chronological load timeline for a single RUM view occurrence on web or mobile. Returns every resource, long task, error, and user interaction during that view, ordered by start time. Use this to investigate one concrete page load or screen. For the aggregated, cross-session view, use `get_rum_insight`.
 
 - Show the full waterfall for the RUM view with ID `AwAAc3dhcmV`.
 - Why did the checkout page load with view UUID `d64b1e7c-8f2a-4c3b-9e1d-5a6b7c8d9e0f` take 12 seconds?


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Aligns the RUM MCP tools reference with the tool definitions shipped in the Datadog MCP Server (rum-mcp). A cross-check of every documented RUM tool against its source definition surfaced a drifts:

- `get_rum_view_waterfall` (GA, `rum` toolset) was missing from the tools reference entirely. It reconstructs the chronological load timeline of a single RUM view occurrence.

### Changes

- Adds a `get_rum_view_waterfall` section after `get_rum_insight`, with toolset, permissions, description, and example prompts matching the house format.

### Merge instructions

Merge readiness:
- [x] Ready for merge