### PR TITLE
chore: document dynamic auto test retries feature for Python

### DIFF
--- a/hugo/content/en/tests/flaky_tests/auto_test_retries.md
+++ b/hugo/content/en/tests/flaky_tests/auto_test_retries.md
@@ -153,7 +153,7 @@ After you set up Test Optimization, configure Auto Test Retries in [{{< ui >}}CI
 
 The default behavior of the feature is to retry any failing test case up to five times. Tests that originally fail either the original setup, teardown, or fixtures in Pytest, are not retried.
 
-Customize this behavior with the following environment variables:
+You can fine tune this behavior with the following environment variables:
 
 * `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` - set to `0` or `false` to explicitly disable retries even if the remote setting is enabled (default: `true`)
 * `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - a non-negative number to change the maximum number of retries per test case (default: `5`).

--- a/hugo/content/en/tests/flaky_tests/auto_test_retries.md
+++ b/hugo/content/en/tests/flaky_tests/auto_test_retries.md
@@ -159,11 +159,11 @@ Customize this behavior with the following environment variables:
 * `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - a non-negative number to change the maximum number of retries per test case (default: `5`).
 * `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: `1000`)
 
-### Dynamic retry budgets
+### Dynamic Auto Test Retries
 
 `dd-trace-py >= 4.15.0`
 
-By default, Auto Test Retries applies the same retry limit to every failing test. Dynamic retry budgets base the number of retries on how long the test takes to run on its first attempt. Faster tests receive more retries and slower tests receive fewer.
+By default, Auto Test Retries applies the same retry limit to every failing test. Dynamic Auto Test Retries (Dynamic ATR) bases the number of retries on how long the test takes to run on its first attempt. Faster tests receive more retries and slower tests receive fewer.
 
 The retry budget for a test is determined once, from the duration of its initial attempt, and applies to all of its retries. A test stops being retried as soon as a retry passes.
 
@@ -179,14 +179,14 @@ The duration buckets are the same as the ones [Early Flake Detection][3] uses:
 
 By default, the budgets come from the Early Flake Detection retry settings provided by the backend. Every failing test is retried at least once, regardless of its duration.
 
-To enable dynamic retry budgets, set the following environment variables:
+To enable Dynamic Auto Test Retries, set the following environment variables:
 
-* `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` - set to `true` to base the number of retries on the test's first attempt duration instead of the flat `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` limit (default: `false`). The flat limit is ignored while dynamic retry budgets are enabled. Auto Test Retries must be enabled in [{{< ui >}}CI/CD Settings{{< /ui >}}][1].
+* `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` - set to `true` to base the number of retries on the test's first attempt duration instead of the flat `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` limit (default: `false`). The flat limit is ignored while Dynamic ATR is enabled. Auto Test Retries must be enabled in [{{< ui >}}CI/CD Settings{{< /ui >}}][1].
 * `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` - five comma-separated integers between `1` and `20` that override the default budgets in the table above, from the fastest to the slowest duration bucket (for example, `10,4,1,1,1`). If this variable is unset or empty, the Early Flake Detection retry settings from the backend are used.
 
 If `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` contains an invalid value, the library ignores it, logs a warning, and uses the default budgets.
 
-**Note**: The session-level limit `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` still applies when dynamic retry budgets are enabled.
+**Note**: The session-level limit `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` still applies when Dynamic ATR is enabled.
 
 [1]: https://app.datadoghq.com/ci/settings/ci-cd/repositories
 

--- a/hugo/content/en/tests/flaky_tests/auto_test_retries.md
+++ b/hugo/content/en/tests/flaky_tests/auto_test_retries.md
@@ -163,7 +163,11 @@ Customize this behavior with the following environment variables:
 
 `dd-trace-py >= 4.15.0`
 
-By default, Auto Test Retries applies the same retry limit to every failing test. You can instead base the number of retries on how long the test takes to run on its first attempt. Faster tests receive more retries and slower tests receive fewer. The duration buckets are the same as the ones [Early Flake Detection][3] uses.
+By default, Auto Test Retries applies the same retry limit to every failing test. Dynamic retry budgets base the number of retries on how long the test takes to run on its first attempt. Faster tests receive more retries and slower tests receive fewer.
+
+The retry budget for a test is determined once, from the duration of its initial attempt, and applies to all of its retries. A test stops being retried as soon as a retry passes.
+
+The duration buckets are the same as the ones [Early Flake Detection][3] uses:
 
 | First attempt duration | Default retries |
 | ---------------------- | --------------- |
@@ -171,11 +175,13 @@ By default, Auto Test Retries applies the same retry limit to every failing test
 | 5-10 seconds | 5 |
 | 10-30 seconds | 3 |
 | 30 seconds-5 minutes | 2 |
-| More than 5 minutes | 0 |
+| More than 5 minutes | 1 |
+
+By default, the budgets come from the Early Flake Detection retry settings provided by the backend. Every failing test is retried at least once, regardless of its duration.
 
 To enable dynamic retry budgets, set the following environment variables:
 
-* `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` - set to `true` to base the number of retries on the test's first attempt duration instead of the flat `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` limit (default: `false`). Auto Test Retries must be enabled in [{{< ui >}}CI/CD Settings{{< /ui >}}][1].
+* `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` - set to `true` to base the number of retries on the test's first attempt duration instead of the flat `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` limit (default: `false`). The flat limit is ignored while dynamic retry budgets are enabled. Auto Test Retries must be enabled in [{{< ui >}}CI/CD Settings{{< /ui >}}][1].
 * `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` - five comma-separated integers between `1` and `20` that override the default budgets in the table above, from the fastest to the slowest duration bucket (for example, `10,4,1,1,1`). If this variable is unset or empty, the Early Flake Detection retry settings from the backend are used.
 
 If `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` contains an invalid value, the library ignores it, logs a warning, and uses the default budgets.

--- a/hugo/content/en/tests/flaky_tests/auto_test_retries.md
+++ b/hugo/content/en/tests/flaky_tests/auto_test_retries.md
@@ -153,11 +153,34 @@ After you set up Test Optimization, configure Auto Test Retries in [{{< ui >}}CI
 
 The default behavior of the feature is to retry any failing test case up to five times. Tests that originally fail either the original setup, teardown, or fixtures in Pytest, are not retried.
 
-You can fine tune this behavior with the following environment variables:
+Customize this behavior with the following environment variables:
 
 * `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` - set to `0` or `false` to explicitly disable retries even if the remote setting is enabled (default: `true`)
 * `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - a non-negative number to change the maximum number of retries per test case (default: `5`).
 * `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: `1000`)
+
+### Dynamic retry budgets
+
+`dd-trace-py >= 4.15.0`
+
+By default, Auto Test Retries applies the same retry limit to every failing test. You can instead base the number of retries on how long the test takes to run on its first attempt. Faster tests receive more retries and slower tests receive fewer. The duration buckets are the same as the ones [Early Flake Detection][3] uses.
+
+| First attempt duration | Default retries |
+| ---------------------- | --------------- |
+| 5 seconds or fewer | 10 |
+| 5-10 seconds | 5 |
+| 10-30 seconds | 3 |
+| 30 seconds-5 minutes | 2 |
+| More than 5 minutes | 0 |
+
+To enable dynamic retry budgets, set the following environment variables:
+
+* `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` - set to `true` to base the number of retries on the test's first attempt duration instead of the flat `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` limit (default: `false`). Auto Test Retries must be enabled in [{{< ui >}}CI/CD Settings{{< /ui >}}][1].
+* `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` - five comma-separated integers between `1` and `20` that override the default budgets in the table above, from the fastest to the slowest duration bucket (for example, `10,4,1,1,1`). If this variable is unset or empty, the Early Flake Detection retry settings from the backend are used.
+
+If `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` contains an invalid value, the library ignores it, logs a warning, and uses the default budgets.
+
+**Note**: The session-level limit `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` still applies when dynamic retry budgets are enabled.
 
 [1]: https://app.datadoghq.com/ci/settings/ci-cd/repositories
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Documents Dynamic Auto Test Retries for Python in the Auto Test Retries page: retry budgets based on the test's first-attempt duration, using the same buckets as Early Flake Detection, controlled by `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` and `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS`. 

Implements docs for DataDog/dd-trace-py#20028.

### Merge readiness

- [x] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
