### PR TITLE
[WEB-9736] Fix misaligned table headers in AWS integration and CloudWatch FAQ

### DIFF
--- a/hugo/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
+++ b/hugo/content/en/integrations/guide/aws-integration-and-cloudwatch-faq.md
@@ -82,7 +82,7 @@ If you recently enabled a new AWS service integration but are not seeing metrics
 
 ### What is the difference between API polling and CloudWatch Metric Streams?
 
-| | API polling (default) | CloudWatch Metric Streams |
+| &nbsp; | API polling (default) | CloudWatch Metric Streams |
 |---|---|---|
 | **Typical latency** | ~10 minutes | 2-3 minutes |
 | **Setup** | Included with the AWS integration | Requires separate setup with [Amazon Data Firehose][6] |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes WEB-9736

The column headers in the "API polling (Default) vs. CloudWatch Metric Streams" table on the AWS integration and CloudWatch FAQ page were shifted one column to the left because the table's empty corner cell was being hidden by CSS, collapsing that column. Giving the cell non-breaking-space content keeps it in place so the headers align correctly with the rows below.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to locate the affected markdown table and CSS rule, and to apply the fix.

### Additional notes