### PR TITLE
Add Architecture Center crosslinks to OpenTelemetry setup docs

### DIFF
--- a/hugo/content/en/opentelemetry/config/otlp_receiver.md
+++ b/hugo/content/en/opentelemetry/config/otlp_receiver.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "/opentelemetry/otlp_ingest_in_the_agent/"
   tag: "Documentation"
   text: "OTLP Ingestion by the Datadog Agent"
+- link: "https://www.datadoghq.com/architecture/datadog-agent-otlp-receiver-in-kubernetes/"
+  tag: "Architecture Center"
+  text: "Datadog Agent OTLP Receiver in Kubernetes"
 ---
 
 ## Overview

--- a/hugo/content/en/opentelemetry/setup/collector_exporter/_index.md
+++ b/hugo/content/en/opentelemetry/setup/collector_exporter/_index.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/opentelemetry/compatibility/"
   tag: "Documentation"
   text: "Feature Compatibility"
+- link: "https://www.datadoghq.com/architecture/opentelemetry-collector-in-kubernetes/"
+  tag: "Architecture Center"
+  text: "OpenTelemetry Collector in Kubernetes"
 ---
 
 ## Overview

--- a/hugo/content/en/opentelemetry/setup/collector_exporter/deploy.md
+++ b/hugo/content/en/opentelemetry/setup/collector_exporter/deploy.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "https://opentelemetry.io/docs/collector/deployment/"
   tag: "External Site"
   text: "OpenTelemetry Collector Deployment"
+- link: "https://www.datadoghq.com/architecture/opentelemetry-collector-in-kubernetes/"
+  tag: "Architecture Center"
+  text: "OpenTelemetry Collector in Kubernetes"
 ---
 
 This page guides you through various deployment options for the OpenTelemetry Collector with the Datadog Exporter, allowing you to send traces, metrics, and logs to Datadog.

--- a/hugo/content/en/opentelemetry/setup/ddot_collector/_index.md
+++ b/hugo/content/en/opentelemetry/setup/ddot_collector/_index.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-distribution-otel-collector/"
   tag: "Blog"
   text: "Unify OpenTelemetry and Datadog with the DDOT Collector"
+- link: "https://www.datadoghq.com/architecture/monitoring-kubernetes-with-datadog-distribution/"
+  tag: "Architecture Center"
+  text: "Monitoring Kubernetes with Datadog Distribution of the OpenTelemetry (DDOT) Collector"
 
 ---
 

--- a/hugo/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
+++ b/hugo/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
@@ -16,6 +16,9 @@ further_reading:
 - link: "/opentelemetry/runtime_metrics/"
   tag: "Documentation"
   text: "OpenTelemetry Runtime Metrics"
+- link: "https://www.datadoghq.com/architecture/datadog-agent-otlp-receiver-in-kubernetes/"
+  tag: "Architecture Center"
+  text: "Datadog Agent OTLP Receiver in Kubernetes"
 ---
 
 


### PR DESCRIPTION
Add crosslinks to Architecture Center reference architectures from related OpenTelemetry setup docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)