### PR TITLE
Add Architecture Center crosslinks to logs and Observability Pipelines docs

### DIFF
--- a/hugo/content/en/logs/guide/best-practices-for-log-management.md
+++ b/hugo/content/en/logs/guide/best-practices-for-log-management.md
@@ -4,6 +4,9 @@ description: 'Best practices for managing and monitoring your logs efficiently i
 aliases:
     - /logs/guide/logs-monitors-on-volumes/
 further_reading:
+    - link: "https://www.datadoghq.com/architecture/a-guide-to-log-management-indexing-strategies-with-datadog/"
+      tag: "Architecture Center"
+      text: "A guide to Log Management Indexing Strategies with Datadog"
     - link: "/logs/log_configuration/processors"
       tag: "Documentation"
       text: "Learn how to process your logs"

--- a/hugo/content/en/logs/log_configuration/indexes.md
+++ b/hugo/content/en/logs/log_configuration/indexes.md
@@ -5,6 +5,9 @@ aliases:
   - /logs/dynamic_volume_control
   - /logs/indexes/
 further_reading:
+- link: "https://www.datadoghq.com/architecture/a-guide-to-log-management-indexing-strategies-with-datadog/"
+  tag: "Architecture Center"
+  text: "A guide to Log Management Indexing Strategies with Datadog"
 - link: "/logs/explorer/#visualize"
   tag: "Documentation"
   text: "Perform Log Analytics"

--- a/hugo/content/en/observability_pipelines/configuration/install_the_worker/_index.mdoc.md
+++ b/hugo/content/en/observability_pipelines/configuration/install_the_worker/_index.mdoc.md
@@ -7,6 +7,12 @@ aliases:
     - /observability_pipelines/install_the_worker/set_up_the_worker_in_ecs_fargate/
     - /observability_pipelines/guide/set_up_the_worker_in_ecs_fargate/
 further_reading:
+- link: "https://www.datadoghq.com/architecture/observability-pipelines-kubernetes-deployment/"
+  tag: "Architecture Center"
+  text: "Observability Pipelines Kubernetes Deployment"
+- link: "https://www.datadoghq.com/architecture/op-vm-deployment/"
+  tag: "Architecture Center"
+  text: "Observability Pipelines VM Deployment"
 - link: "/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations/"
   tag: "Documentation"
   text: "Advanced Worker configurations"


### PR DESCRIPTION
Add crosslinks to Architecture Center reference architectures from related log indexing and Observability Pipelines deployment docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)