### PR TITLE
Add Architecture Center crosslinks to DBM docs

### DIFF
--- a/hugo/content/en/database_monitoring/setup_postgres/rds/_index.md
+++ b/hugo/content/en/database_monitoring/setup_postgres/rds/_index.md
@@ -11,6 +11,9 @@ further_reading:
 - link: "/database_monitoring/guide/parameterized_queries/"
   tag: "Documentation"
   text: "Capturing SQL Query Parameter Values"
+- link: "https://www.datadoghq.com/architecture/dbm-quick-install-aws-rds-postgres/"
+  tag: "Architecture Center"
+  text: "Datadog DBM Quick Install for AWS RDS"
 ---
 
 Database Monitoring provides deep visibility into your Postgres databases by exposing query metrics, query samples, explain plans, database states, failovers, and events.

--- a/hugo/content/en/database_monitoring/setup_postgres/rds/quick_install.md
+++ b/hugo/content/en/database_monitoring/setup_postgres/rds/quick_install.md
@@ -7,6 +7,9 @@ further_reading:
 - link: "/database_monitoring/setup_postgres/rds"
   tag: "Documentation"
   text: "Setting Up Database Monitoring for Amazon RDS managed Postgres"
+- link: "https://www.datadoghq.com/architecture/dbm-quick-install-aws-rds-postgres/"
+  tag: "Architecture Center"
+  text: "Datadog DBM Quick Install for AWS RDS"
 ---
 
 Database Monitoring Quick Install for RDS enables you to quickly set up Agents to monitor your RDS Postgres instances. After you specify a few options, Datadog generates a CloudFormation template that configures your instance for monitoring, and uses Amazon ECS to deploy the Agent to the RDS instance with recommended DBM configurations.


### PR DESCRIPTION
Add crosslinks to Architecture Center reference architectures from related Database Monitoring RDS setup docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)