### PR TITLE
Add Architecture Center crosslinks to network monitoring docs

### DIFF
--- a/hugo/content/en/network_monitoring/_index.md
+++ b/hugo/content/en/network_monitoring/_index.md
@@ -3,6 +3,9 @@ title: Network Monitoring
 disable_sidebar: true
 description: Explore Datadog Network Monitoring Products
 further_reading:
+  - link: "https://www.datadoghq.com/architecture/hybrid-cloud-network-observability/"
+    tag: "Architecture Center"
+    text: "Hybrid Multi-cloud Network Observability Reference Architecture"
   - link: "https://app.datadoghq.com/release-notes?category=Network%20Monitoring"
     tag: "Release Notes"
     text: "Check out the latest Datadog Network Monitoring releases! (App login required)."

--- a/hugo/content/en/network_monitoring/cloud_network_monitoring/_index.md
+++ b/hugo/content/en/network_monitoring/cloud_network_monitoring/_index.md
@@ -7,6 +7,9 @@ aliases:
   - /network_performance_monitoring/
   - /network_monitoring/performance/
 further_reading:
+- link: "https://www.datadoghq.com/architecture/hybrid-cloud-network-observability/"
+  tag: "Architecture Center"
+  text: "Hybrid Multi-cloud Network Observability Reference Architecture"
 - link: "https://www.datadoghq.com/blog/cnm-network-health"
   tag: "Blog"
   text: "Detect, diagnose, and resolve network issues easily with CNM Network Health"

--- a/hugo/content/en/network_monitoring/netflow/_index.md
+++ b/hugo/content/en/network_monitoring/netflow/_index.md
@@ -3,6 +3,9 @@ title: NetFlow Monitoring
 aliases:
 - /network_monitoring/devices/netflow/
 further_reading:
+- link: "https://www.datadoghq.com/architecture/hybrid-cloud-network-observability/"
+  tag: "Architecture Center"
+  text: "Hybrid Multi-cloud Network Observability Reference Architecture"
 - link: "/network_monitoring/devices/profiles"
   tag: "Documentation"
   text: "Using Profiles with Network Device Monitoring"


### PR DESCRIPTION
Add crosslinks to Architecture Center reference architectures from related network monitoring docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)