### PR TITLE
Add Architecture Center crosslinks to AWS integration, GPU, and data observability docs

### DIFF
--- a/hugo/content/en/data_observability/_index.md
+++ b/hugo/content/en/data_observability/_index.md
@@ -2,6 +2,12 @@
 title: Data Observability Overview
 description: "Monitor data quality, performance, and cost with Data Observability to detect anomalies, analyze data lineage, and prevent issues affecting downstream systems."
 further_reading:
+ - link: 'https://www.datadoghq.com/architecture/monitoring-financial-data-mesh-on-aws-using-datadog/'
+   tag: 'Architecture Center'
+   text: 'Monitoring Financial Data Mesh on AWS using Datadog'
+ - link: 'https://www.datadoghq.com/architecture/monitoring-insurance-data-lakes-on-aws-using-datadog/'
+   tag: 'Architecture Center'
+   text: 'Monitoring Insurance Data Lakes on AWS using Datadog'
  - link: 'https://www.datadoghq.com/about/latest-news/press-releases/datadog-metaplane-aquistion/'
    tag: 'Blog'
    text: 'Datadog Brings Observability to Data teams by Acquiring Metaplane'

--- a/hugo/content/en/data_observability/quality_monitoring/data_lakes/_index.md
+++ b/hugo/content/en/data_observability/quality_monitoring/data_lakes/_index.md
@@ -5,6 +5,9 @@ further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Data Observability Overview'
+  - link: 'https://www.datadoghq.com/architecture/monitoring-insurance-data-lakes-on-aws-using-datadog/'
+    tag: 'Architecture Center'
+    text: 'Monitoring Insurance Data Lakes on AWS using Datadog'
 ---
 ## Overview
 

--- a/hugo/content/en/data_streams/_index.md
+++ b/hugo/content/en/data_streams/_index.md
@@ -5,6 +5,12 @@ aliases:
 - /data_streams/data_pipeline_lineage
 - /data_streams/business_transaction_tracking
 further_reading:
+    - link: 'https://www.datadoghq.com/architecture/monitoring-financial-data-mesh-on-aws-using-datadog/'
+      tag: 'Architecture Center'
+      text: 'Monitoring Financial Data Mesh on AWS using Datadog'
+    - link: 'https://www.datadoghq.com/architecture/observability-in-event-driven-architecture/'
+      tag: 'Architecture Center'
+      text: 'Observability in Event-Driven Architectures'
     - link: '/integrations/kafka/'
       tag: 'Documentation'
       text: 'Kafka Integration'

--- a/hugo/content/en/getting_started/integrations/aws.md
+++ b/hugo/content/en/getting_started/integrations/aws.md
@@ -2,6 +2,9 @@
 title: Getting Started with AWS
 description: Integrate your Amazon Web Services account with Datadog using CloudFormation. Set up IAM roles, enable service integrations, and configure log forwarding.
 further_reading:
+    - link: 'https://www.datadoghq.com/architecture/a-guide-to-integrating-100-aws-accounts-with-datadog/'
+      tag: 'Architecture Center'
+      text: 'A Guide to Integrating 100+ AWS Accounts with Datadog'
     - link: 'https://www.datadoghq.com/blog/aws-monitoring/'
       tag: 'Blog'
       text: 'Key metrics for AWS monitoring'

--- a/hugo/content/en/gpu_monitoring/_index.md
+++ b/hugo/content/en/gpu_monitoring/_index.md
@@ -1,6 +1,9 @@
 ---
 title: GPU Monitoring
 further_reading:
+- link: "https://www.datadoghq.com/architecture/gpu-monitoring/"
+  tag: "Architecture Center"
+  text: "GPU Monitoring Reference Architecture"
 - link: "/gpu_monitoring/setup"
   tag: "Documentation"
   text: "Set up GPU Monitoring"

--- a/hugo/content/en/gpu_monitoring/setup.md
+++ b/hugo/content/en/gpu_monitoring/setup.md
@@ -1,6 +1,9 @@
 ---
 title: Set up GPU Monitoring
 further_reading:
+- link: "https://www.datadoghq.com/architecture/gpu-monitoring/"
+  tag: "Architecture Center"
+  text: "GPU Monitoring Reference Architecture"
 - link: "/gpu_monitoring/summary"
   tag: "Documentation"
   text: "GPU Monitoring Summary Page"

--- a/hugo/content/en/integrations/guide/aws-organizations-setup.md
+++ b/hugo/content/en/integrations/guide/aws-organizations-setup.md
@@ -3,6 +3,9 @@ title: AWS Integration Multi-Account setup for AWS Organizations
 
 description: "Steps for setting up the Datadog AWS Integration for an AWS Organization"
 further_reading:
+- link: "https://www.datadoghq.com/architecture/a-guide-to-integrating-100-aws-accounts-with-datadog/"
+  tag: "Architecture Center"
+  text: "A Guide to Integrating 100+ AWS Accounts with Datadog"
 - link: "https://docs.datadoghq.com/integrations/guide/aws-integration-troubleshooting/"
   tag: "Guide"
   text: "Troubleshooting the AWS integration" 

--- a/hugo/content/en/integrations/guide/aws-terraform-setup.md
+++ b/hugo/content/en/integrations/guide/aws-terraform-setup.md
@@ -5,6 +5,9 @@ aliases:
     - /integrations/faq/aws-integration-with-terraform/
 disable_toc: true
 further_reading:
+- link: "https://www.datadoghq.com/architecture/a-guide-to-integrating-100-aws-accounts-with-datadog/"
+  tag: "Architecture Center"
+  text: "A Guide to Integrating 100+ AWS Accounts with Datadog"
 - link: "https://www.datadoghq.com/blog/managing-datadog-with-terraform/"
   tag: "Blog"
   text: "Managing Datadog with Terraform"

--- a/hugo/content/en/tracing/_index.md
+++ b/hugo/content/en/tracing/_index.md
@@ -2,6 +2,9 @@
 title: APM
 description: Instrument your code to improve performance
 further_reading:
+  - link: "https://www.datadoghq.com/architecture/observability-in-event-driven-architecture/"
+    tag: "Architecture Center"
+    text: "Observability in Event-Driven Architectures"
   - link: "https://learn.datadoghq.com/courses/getting-started-apm"
     tag: "Learning Center"
     text: "Getting Started with APM Metrics and Traces"


### PR DESCRIPTION
Add crosslinks to Architecture Center reference architectures from related AWS integration, GPU monitoring, and data observability docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)