### PR TITLE
Update Bits Code PR/MR collaboration providers

### DIFF
--- a/hugo/content/en/bits_ai/bits_code/_index.md
+++ b/hugo/content/en/bits_ai/bits_code/_index.md
@@ -110,8 +110,10 @@ Bits Code also [ingests custom instructions][33] defined in your repository and 
 
 Bits Code integrates with [source code providers](#supported-source-code-providers) to:
 - Create pull or merge requests, generating titles and descriptions based on your repository's pull or merge request template
-- Iterate on pull requests in response to comments (GitHub only); mention `@Datadog` in a comment to prompt Bits for updates
+- Iterate on pull or merge requests in response to comments on GitHub, GitLab, and Azure DevOps: mention `@Datadog` in a comment to ask Bits Code for updates
 - Monitor CI logs and pull or merge request state to fix failures and merge blockers
+
+While Bits Code works on your request, it keeps a single status comment up to date on the pull or merge request. The comment shows the state of the run and the actions and links available to you, including a link to the Datadog session when the request is backed by one. When CI Auto-fix is available, the comment also shows its status and controls to fix failing CI checks.
 
 Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is working on in {{< ui >}}Bits AI{{< /ui >}} > {{< ui >}}Bits Code{{< /ui >}} > [{{< ui >}}Sessions{{< /ui >}}][7].
 
@@ -119,7 +121,6 @@ Bits Code never auto-merges PRs or MRs. See all the PRs or MRs that Bits Code is
 
 - Bits Code is an AI product, which means it can make mistakes. Use best practices when reviewing and testing agent-generated code.  
 - Bits Code does not support multi-repository investigations.
-- When using GitLab, mentioning `@Datadog` in a comment to prompt Bits for updates is not supported.
 
 ## Further reading
 

--- a/hugo/content/en/bits_ai/bits_code/setup.md
+++ b/hugo/content/en/bits_ai/bits_code/setup.md
@@ -72,6 +72,7 @@ Set up Bits Code for one of the [supported source code providers][11].
    - Contribute to pull requests
    - Create branch
    - Read
+3. To make CI Auto-fix available in the status comment on pull requests, verify that the service principal can [view builds][105] on each project. Without this permission, the status comment prompts you to grant it instead of offering to fix failing CI checks.
 
 If [commit author email validation][104] is enabled, add `no-reply@dtdg.co` to the allowed email addresses. Bits Code uses this address for commits it creates.
 
@@ -79,6 +80,7 @@ If [commit author email validation][104] is enabled, add `no-reply@dtdg.co` to t
 [102]: /integrations/azure-devops-source-code/
 [103]: https://learn.microsoft.com/en-us/azure/devops/repos/git/set-git-repository-permissions
 [104]: https://learn.microsoft.com/en-us/azure/devops/repos/git/repository-settings#commit-author-email-validation-policy
+[105]: https://learn.microsoft.com/en-us/azure/devops/pipelines/policies/permissions
 {{% /tab %}}
 
 {{< /tabs >}}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d90bb369-020c-487d-89a4-526eb8f9d93e","source":"chat","resourceId":"63b05e15-38af-4681-8330-a5b0e25395e9","workflowId":"f04591b7-d40d-46c4-998d-16b95eacfb08","codeChangeId":"f04591b7-d40d-46c4-998d-16b95eacfb08","sourceType":"llm-obs-docs-agent"} -->
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Bits Code supports `@Datadog` mentions in GitLab merge request and Azure DevOps pull request comments, and it maintains a status comment on the pull or merge request while it works on a request. The docs still described mentions as GitHub-only, listed GitLab as an explicit limitation, and didn't cover the Azure DevOps permission that the status comment's CI Auto-fix action depends on.

Source PR: https://github.com/DataDog/code-gen-backend/pull/15137

### Changes

- The pull or merge request collaboration section covers `@Datadog` mentions on GitHub, GitLab, and Azure DevOps, and describes what customers see in the status comment: the run state, the actions and links available to them, a link to the Datadog session, and CI Auto-fix status and controls when available.
- The obsolete GitLab limitation is gone, so the page no longer contradicts itself about provider support.
- The Azure DevOps setup tab asks customers to let the integration service principal view builds, and states the fallback: if the permission is missing, the status comment prompts for it instead of offering an action that can't succeed.

Both edits stay in the shape of what they touch — a reworded bullet and a short paragraph in an existing prose section, and one numbered step alongside the other Azure DevOps setup requirements. No renderer, event, or permission-check internals are described.

### Testing

- Verified the Markdown structure of the new Azure DevOps step: it continues the tab's existing numbered list, and the new `[105]` reference link is defined inside the same tab block as that tab's other reference links.
- Grepped the overview page for leftover GitHub-only claims about mentions; the only remaining provider-specific wording is the supported-providers list, which is unchanged and already lists all three providers.
- Vale was not run: the binary and its `../datadog-vale` styles are not available in this environment. The new copy was checked by hand against the substitution list in `CLAUDE.md` (no "ensure", "via", "just", "currently/now", or filler words).
- The new Microsoft Learn link for build permissions could not be opened from this environment (external fetches are blocked), so it's worth one click during review.

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Bits Code (Claude Code); wording reviewed manually against the repo style guide.

### Additional notes

No Jira ticket was provided for this change, so the title omits a `DOCS-` key.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/63b05e15-38af-4681-8330-a5b0e25395e9)

Comment @datadog to request changes