### PR TITLE
Remove code execution preview language

### DIFF
--- a/hugo/content/en/mcp_server/setup.md
+++ b/hugo/content/en/mcp_server/setup.md
@@ -710,6 +710,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `core`: The default toolset for logs, metrics, traces, dashboards, monitors, incidents, hosts, services, events, and notebooks
 - `alerting`: Tools for validating and creating monitors, searching monitor groups, retrieving monitor templates, analyzing monitor coverage, and searching SLOs
 - `audit-trail`: Tools for [Audit Trail][70], including searching and retrieving Audit Trail events and forming Audit Trail search queries
+- `code-exec`: A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 - `cost`: Tools for [Cloud Cost Management][63], including listing cost-saving recommendations ranked by estimated potential daily savings
 - `dashboards`: Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation
 - `data-observability`: Tools for [Data Observability][69], including data catalog search, lineage analysis, data quality monitoring, and cost and performance recommendations for data warehouses and Spark jobs
@@ -737,7 +738,6 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 These toolsets are in Preview and are not included in the `all` alias; request them explicitly by name. Access requirements vary by toolset, as noted below. Where a Product Preview form is listed, sign up through it or contact [Datadog support][47] to request access.
 - `apm`: ([Sign up][45]) Tools for in-depth [APM][34] trace analysis, span search, Watchdog insights, and performance investigation
 - `cases`: Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues. No sign-up or access request required.
-- `code-exec`: ([Sign up][60]) A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call
 - `remote-actions`: ([Sign up][62]) Tools for on-host diagnostics, including reading files, listing directories, and running safe read-only shell commands directly on instrumented hosts through the Agent
 
 ## Supported clients
@@ -969,7 +969,6 @@ Local authentication is recommended for Cline and when remote authentication is 
 [57]: /real_user_monitoring/
 [58]: /getting_started/profiler/
 [59]: https://chatgpt.com/
-[60]: https://www.datadoghq.com/product-preview/mcp-codexec/
 [61]: https://partners.datadoghq.com/s/login/SelfRegister
 [62]: https://www.datadoghq.com/product-preview/datadog-agent-mcp/
 [63]: /cloud_cost_management/

--- a/hugo/content/en/mcp_server/tools.md
+++ b/hugo/content/en/mcp_server/tools.md
@@ -508,8 +508,6 @@ Lists an organization's Cloud Cost Management cost-saving recommendations, ranke
 
 A single tool that runs agent-authored TypeScript in a Datadog-managed sandbox with direct access to Datadog APIs, for multi-signal investigation and ad-hoc data exploration in one call.
 
-<div class="alert alert-info">The <code>code-exec</code> toolset is in Preview. <a href="https://www.datadoghq.com/product-preview/mcp-codexec/">Sign up</a> for the preview or contact <a href="/help">Datadog support</a> to request access.</div>
-
 Code executed by this toolset runs against your Datadog APIs using your own user identity. The sandbox applies your existing [role permissions][56] to every API call, so an agent can only read or modify data that you can already access in Datadog.
 
 ### `execute_code`


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Code Exec is now GA!
Removes Preview language for the MCP Server Code Execution toolset now that it is generally available.

### Merge readiness

- [ ] Ready for merge

### AI assistance

Used Codex to update the MCP Server documentation and open this draft PR.

### Additional notes

Vale was not available locally; git diff --check passed.