### PR TITLE
[DOCS-15136] Fix incorrect Last used gating claim in api-app-keys.md

### DIFF
--- a/hugo/content/en/account_management/api-app-keys.md
+++ b/hugo/content/en/account_management/api-app-keys.md
@@ -60,7 +60,7 @@ In order to use application keys with these APIs, you must enable Actions API ac
 
 {{< img src="account_management/click-enable-actions-api-access.png" alt="Click Enable for Actions API Access" style="width:80%;" >}}
 
-**Note**: The {{< ui >}}Last used{{< /ui >}} section only shows if [Audit Trail is enabled][22] in the account and you have [`Audit Trail Read`][23] permission.
+**Note**: The {{< ui >}}Last used{{< /ui >}} timestamp is visible to all customers. [Audit Trail][22] extends how far back this information is available.
 
 ## Client tokens
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15136

The API and Application Keys page stated that the **Last used** timestamp only shows if Audit Trail is enabled and the viewer has `Audit Trail Read` permission. That's incorrect: the timestamp is visible to all customers, with Audit Trail extending how far back it's available. This corrects the note to reflect actual behavior.

### Merge readiness

- [x] Ready for merge

## For Datadog employees:

### AI assistance

Investigated and drafted with Claude Code, based on SME confirmation from an engineer on the credentials team (see DOCS-15136 comments).

### Additional notes

Split off from DOCS-15136, which remains blocked on other SME questions (SAT/PAT limit values, plan tier numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)