### PR TITLE
[DOCS-15576] Clarify vague Pages wording in On-Call concepts

### DIFF
--- a/hugo/content/en/incident_response/on-call/_index.md
+++ b/hugo/content/en/incident_response/on-call/_index.md
@@ -26,7 +26,7 @@ Datadog On-Call integrates monitoring, paging, and incident response into one pl
 
 ## Concepts
 
-- **Pages** represent something to get alerted for, such as a monitor, incident, or security signal. A Page can have a status of `Triggered`, `Acknowledged`, or `Resolved`.
+- **Pages** represent an event to get alerted for, such as a monitor, incident, or security signal. A Page can have a status of `Triggered`, `Acknowledged`, or `Resolved`.
 - **Teams** are groups configured within Datadog to handle specific types of Pages, based on expertise and operational roles.
 - **Routing rules** allow Teams to finely adjust their reactions to specific types of incoming events. These rules can set a Page's urgency level, route Pages to different escalation policies depending on the event's metadata, and configure [support hours][7] to delay escalation notifications to defined time windows.
 - **Escalation policies** determine how Pages are escalated within or across Teams.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15576

A customer flagged the On-Call concepts section for describing Pages as representing "something to get alerted for," which reads as vague. This swaps "something" for "an event," keeping the existing examples (monitor, incident, security signal) that already clarify the concept.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Drafted with Claude Code.

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)