### PR TITLE
[DOCS-15348] Align Manual tab step order for AAS Linux sidecar setup

### DIFF
--- a/hugo/content/en/serverless/azure_app_service/linux_code.md
+++ b/hugo/content/en/serverless/azure_app_service/linux_code.md
@@ -359,7 +359,23 @@ See the [Manual tab](?tab=manual#instrumentation) for descriptions of all enviro
 {{% /tab %}}
 {{% tab "Manual" %}}
 
-1. **Configure environment variables**.
+1. **Configure a sidecar container for Datadog**.
+
+   1. In Azure, navigate to {{< ui >}}Deployment{{< /ui >}} > {{< ui >}}Deployment Center{{< /ui >}}. Select the {{< ui >}}Containers{{< /ui >}} tab.
+   1. Click {{< ui >}}Add{{< /ui >}} and select {{< ui >}}Custom container{{< /ui >}}.
+   1. In the {{< ui >}}Edit container{{< /ui >}} form, provide the following:
+      - {{< ui >}}Image source{{< /ui >}}: Other container registries
+      - {{< ui >}}Image type{{< /ui >}}: Public
+      - {{< ui >}}Registry server URL{{< /ui >}}: `index.docker.io`
+      - {{< ui >}}Image and tag{{< /ui >}}: `datadog/serverless-init:latest`
+      - {{< ui >}}Port{{< /ui >}}: 8126
+      - Under {{< ui >}}Environment variables{{< /ui >}}, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
+
+        {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
+
+   1. Select {{< ui >}}Apply{{< /ui >}}.
+
+2. **Configure environment variables**.
    In Azure, add the following key-value pairs in {{< ui >}}Settings{{< /ui >}} > {{< ui >}}Environment Variables{{< /ui >}} > {{< ui >}}App Settings{{< /ui >}}:
 
 `DD_API_KEY`
@@ -431,26 +447,6 @@ Path to the instrumentation library loaded by the .NET runtime.<br>
 [1]: https://www.nuget.org/packages/Datadog.Trace.Bundle#readme-body-tab
 
 {{% /collapse-content %}}
-
-2. **Configure a sidecar container for Datadog**.
-
-   1. In Azure, navigate to {{< ui >}}Deployment{{< /ui >}} > {{< ui >}}Deployment Center{{< /ui >}}. Select the {{< ui >}}Containers{{< /ui >}} tab.
-   1. Click {{< ui >}}Add{{< /ui >}} and select {{< ui >}}Custom container{{< /ui >}}.
-   1. In the {{< ui >}}Edit container{{< /ui >}} form, provide the following:
-      - {{< ui >}}Image source{{< /ui >}}: Other container registries
-      - {{< ui >}}Image type{{< /ui >}}: Public
-      - {{< ui >}}Registry server URL{{< /ui >}}: `index.docker.io`
-      - {{< ui >}}Image and tag{{< /ui >}}: `datadog/serverless-init:latest`
-      - {{< ui >}}Port{{< /ui >}}: 8126
-      - Under {{< ui >}}Environment variables{{< /ui >}}, enable the {{< ui >}}Allow access to all app settings{{< /ui >}} option.
-
-        {{< img src="serverless/azure_app_service/app_settings.png" alt="In Azure, an Environment Variables section. An 'Allow access to all app settings' option is enabled with a checkbox." >}}
-
-   1. Select {{< ui >}}Apply{{< /ui >}}.
-
-3. **Restart your application**.
-
-   If you modified a startup command, restart your application. Azure automatically restarts the application when new Application Settings are saved.
 
 [301]: https://app.datadoghq.com/organization-settings/api-keys
 [302]: /getting_started/site/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-15348

Aligns the **Manual** tab step order in the Linux Code Azure App Service page with the Linux Container page: configure the sidecar container first, then configure environment variables. Also removes the separate "Restart your application" step, since Azure automatically restarts the app when Application Settings change (matching how the Container page already presents this flow).

### Merge readiness

- [x] Ready for merge

### AI assistance

Used Claude Code to identify the step-order discrepancy between the two pages and apply the reordering.

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)