### PR TITLE
Document OpenLineage events view for verifying job runs

### DIFF
--- a/hugo/content/en/data_observability/jobs_monitoring/openlineage/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/openlineage/_index.md
@@ -517,6 +517,12 @@ After sending your events, check the following:
 
 - [**Jobs Monitoring**][7]: Your job run appears with start time, duration, and status.
 - [**Lineage graph**][9]: If you included `inputs` or `outputs` in your event, your job appears as a node connected to the dataset nodes.
+- [**OpenLineage events**][12]: Every event Datadog received from you, newest first, with a
+  validation status of `Ok`, `Warning`, or `Error`. Select an event to see the exact
+  payload as received, and filter by validation status to find events that were
+  accepted but rejected during processing. Start here whenever an event returned
+  `201` but nothing appeared in the two views above — a `201` confirms delivery, not
+  that the event described something Datadog could use.
 
 ## Correlate logs with job runs
 
@@ -629,3 +635,4 @@ Tags on `job.facets.tags` and `run.facets.tags` behave differently:
 [9]: https://app.datadoghq.com/data-obs/lineage
 [10]: /logs/log_collection/
 [11]: /tracing/trace_explorer/?tab=listview
+[12]: https://app.datadoghq.com/data-obs/settings/open-lineage

--- a/hugo/content/en/data_observability/jobs_monitoring/openlineage/_index.md
+++ b/hugo/content/en/data_observability/jobs_monitoring/openlineage/_index.md
@@ -520,7 +520,7 @@ After sending your events, check the following:
 - [**OpenLineage events**][12]: Every event Datadog received from you, newest first, with a
   validation status of `Ok`, `Warning`, or `Error`. Select an event to see the exact
   payload as received, and filter by validation status to find events that were
-  accepted but rejected during processing. Start here whenever an event returned
+  accepted over HTTP but rejected during validation. Start here whenever an event returned
   `201` but nothing appeared in the two views above — a `201` confirms delivery, not
   that the event described something Datadog could use.
 


### PR DESCRIPTION
Add a third verification step pointing to the OpenLineage events view, where customers can check validation status and payloads for events Datadog received.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

<!-- _Brief_ description of context for changes, the problem you're solving, from the user's and reviewer's perspectives, NOT a detailed itemization or justification. The reviewer needs to be able to quickly understand why the changes were made. Keep it short. See [PR Etiquette](https://github.com/DataDog/documentation#pr-etiquette) for examples. -->

### Merge readiness

- [ ] Ready for merge
<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. If the PR is ready to be merged once it receives the required reviews, check the box above after you've created the PR.
-->

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
