### PR TITLE
Bits AI unavailable for GovCloud in Log Findings

### DIFF
--- a/hugo/content/en/logs/explorer/findings.md
+++ b/hugo/content/en/logs/explorer/findings.md
@@ -74,6 +74,12 @@ Each finding keeps the query and absolute time range. In Log Explorer, you can c
 
 ## Send findings to Bits AI and Notebooks
 
+{{% site-region region="gov,gov2" %}}
+<div class="alert alert-danger">
+Bits AI is not available in the <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}). You can still add findings to a Notebook.
+</div>
+{{% /site-region %}}
+
 Select one or more findings to act on them together:
 
 - To ask [Bits Chat][2] about them, type your question in the selection bar and click {{< ui >}}Ask Bits{{< /ui >}}. You can also click {{< ui >}}Ask Bits{{< /ui >}} in the menu at the bottom of the Findings panel after selecting the findings. Bits Chat opens with the selected findings attached as context.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Hotfix to add banner for Log Findings GOV sites noting Bits AI is unavailable.

### Merge readiness

- [X] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews your PR.

### AI assistance

Used Claude Code to find the existing site-region precedent and draft the banner.

### Additional notes
