### PR TITLE
[DOCS-15670] Replace deprecated Kafka JMX setup

### DIFF
--- a/hugo/content/en/opentelemetry/integrations/kafka_metrics.md
+++ b/hugo/content/en/opentelemetry/integrations/kafka_metrics.md
@@ -9,12 +9,9 @@ further_reading:
 
 ## Overview
 
-{{< img src="/opentelemetry/collector_exporter/kafka_metrics.png" alt="OpenTelemetry Kafka metrics in OOTB Kafka dashboard" style="width:100%;" >}}
+{{< img src="/opentelemetry/collector_exporter/kafka_metrics.png" alt="OpenTelemetry Kafka metrics in the Kafka dashboard" style="width:100%;" >}}
 
-The [Kafka metrics receiver][1], [JMX Receiver][2]/ [JMX Metrics Gatherer][3] allow collecting Kafka metrics and access to the out of the box [Kafka Dashboard][7], "Kafka, Zookeeper and Kafka Consumer Overview". 
-
-**Note**: the [JMX Receiver][2] and [JMX Metrics Gatherer][3] should be considered as replacements. They collect the same set of metrics ([JMX Receiver][2] launches the [JMX Metrics Gatherer][3]).
-
+The [Kafka metrics receiver][1] and [JMX Scraper][2] collect Kafka metrics for the out-of-the-box [Kafka Dashboard][7], **Kafka, Zookeeper and Kafka Consumer Overview**.
 
 ## Kafka metrics receiver
 
@@ -36,14 +33,15 @@ receivers:
 
 {{% tab "Kubernetes" %}}
 
-The Kafka metrics receiver needs to be used in a collector in `deployment` mode with a single replica. This ensures that the same metric is not collected multiple times. The collector in deployment mode can then leverage the Datadog Exporter to export the metrics directly to Datadog, or leverage the OTLP exporter to forward the metrics to another collector instance. 
+Run the Kafka metrics receiver in a single-replica Collector deployment to prevent duplicate metrics. The Collector can export metrics directly to Datadog over OTLP HTTP or forward them to another Collector.
 
-Add the following lines to `values.yaml`:
+Set the deployment mode in `values.yaml`:
+
 ```yaml
 mode: deployment
 ```
 
-Add the following in the Collector configuration:
+Add the receiver to the Collector configuration:
 
 ```yaml
 receivers:
@@ -60,174 +58,109 @@ receivers:
 
 {{< /tabs >}}
 
-## JMX receiver
+## JMX Scraper
+
+The JMX Scraper runs as a standalone Java application and sends metrics to the Collector's OTLP receiver.
+
+### Configure Kafka brokers
+
+Configure JMX authentication and TLS for your environment. Add these JVM options to each Kafka broker:
+
+```shell
+-Dcom.sun.management.jmxremote=true
+-Dcom.sun.management.jmxremote.port=9999
+-Dcom.sun.management.jmxremote.rmi.port=9999
+-Dcom.sun.management.jmxremote.local.only=false
+-Djava.rmi.server.hostname=<BROKER_HOSTNAME_OR_IP>
+```
+
+Set `java.rmi.server.hostname` to the hostname or IP address that the scraper uses to connect. The broker includes this value in an RMI stub, and the scraper opens a second connection to it.
+
+- Do not use `0.0.0.0`, which is a bind address rather than a routable address.
+- Use a loopback address only when the scraper runs on the broker's host or Pod.
+- In Kubernetes, use the broker Pod IP or a DNS name.
+
+Set `jmxremote.rmi.port` to the same port as `jmxremote.port`. Without a fixed RMI port, the second connection uses a random port that a firewall or port mapping might block. For Kafka containers, set `KAFKA_JMX_HOSTNAME` to the same address as `java.rmi.server.hostname`.
+
+An unreachable address can allow the initial connection to succeed, but the scrape then fails with `Failed to retrieve RMIServer stub` or `Connection refused to host: <UNREACHABLE_ADDRESS>`.
+
+### Run the JMX Scraper
+
+Set `otel.jmx.target.source` to `legacy` to preserve the JVM metric names expected by existing dashboards and monitors.
 
 {{< tabs >}}
 {{% tab "Host" %}}
 
-The JMX Receiver has the following requirements:
-- JRE is available on the host where you are running the collector.
-- The JMX Metric Gatherer JAR is available on the host where you are running the collector. You can download the most recent release of the JMX Metric Gatherer JAR from the [opentelemetry-java-contrib releases page][1].
+Install a JRE on the host that runs the JMX Scraper. On Debian or Ubuntu, run:
 
-Add the following in the Collector configuration:
-
-```yaml
-receivers:
-  jmx:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_BROKER_JMX_ADDRESS}
-    target_system: kafka,jvm
-  jmx/consumer:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_CONSUMER_JMX_ADDRESS}
-    target_system: kafka-consumer
-  jmx/producer:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_PRODUCER_JMX_ADDRESS}
-    target_system: kafka-producer
-```
-
-[1]: https://github.com/open-telemetry/opentelemetry-java-contrib/releases
-
-{{% /tab %}}
-
-{{% tab "Kubernetes" %}}
-
-The JMX receiver needs to be used in a collector in `deployment` mode with a single replica. This ensures that the same metric is not collected multiple times. The collector in deployment mode can then leverage the Datadog Exporter to export the metrics directly to Datadog, or leverage the OTLP exporter to forward the metrics to another collector instance. 
-
-The JMX Receiver has the following requirements:
-- JRE is available on the host in which you are running the collector.
-- The JMX Metric Gatherer JAR is available on the host in which you are running the collector. You can download the most recent release of the JMX Metric Gatherer JAR [here][1].
-
-Because the OTel collector default image does not meet the requirements above, a custom image needs to be built. See the Dockerfile below for an example image that contains the collector binary, JRE, and JMX Metrics Gatherer Jar.
-
-Dockerfile:
-```Dockerfile
-FROM alpine:latest as prep
-
-# OpenTelemetry Collector Binary
-ARG OTEL_VERSION=0.92.0
-ARG TARGETARCH=linux_amd64
-ADD "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTEL_VERSION}/otelcol-contrib_${OTEL_VERSION}_${TARGETARCH}.tar.gz" /otelcontribcol
-RUN tar -zxvf /otelcontribcol
-
-# JMX Metrics Gatherer Jar
-ARG JMX_GATHERER_JAR_VERSION=1.27.0
-ADD https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v${JMX_GATHERER_JAR_VERSION}/opentelemetry-jmx-metrics.jar /opt/opentelemetry-jmx-metrics.jar
-# nonroot user id (https://groups.google.com/g/distroless-users/c/-DpzCr7xRDY/m/eQqJmJroCgAJ)
-ARG USER_UID=65532
-RUN chown ${USER_UID} /opt/opentelemetry-jmx-metrics.jar
-
-
-FROM gcr.io/distroless/java17-debian11:nonroot
-
-COPY --from=prep /opt/opentelemetry-jmx-metrics.jar /opt/opentelemetry-jmx-metrics.jar
-COPY --from=prep /otelcol-contrib /otelcol-contrib
-
-EXPOSE 4317 55680 55679
-ENTRYPOINT ["/otelcol-contrib"]
-CMD ["--config", "/etc/otelcol-contrib/config.yaml"]
-```
-
-Add the following lines to `values.yaml`:
-```yaml
-mode: deployment
-```
-
-Add the following in the Collector configuration:
-
-```yaml
-receivers:
-  jmx:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_BROKER_JMX_ADDRESS}
-    target_system: kafka,jvm
-  jmx/consumer:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_CONSUMER_JMX_ADDRESS}
-    target_system: kafka-consumer
-  jmx/producer:
-    jar_path: /path/to/opentelemetry-jmx-metrics.jar
-    endpoint: ${env:KAFKA_PRODUCER_JMX_ADDRESS}
-    target_system: kafka-producer
-```
-
-[1]: https://github.com/open-telemetry/opentelemetry-java-contrib/releases
-
-
-{{% /tab %}}
-
-{{< /tabs >}}
-
-
-## JMX Metrics Gatherer
-
-{{< tabs >}}
-{{% tab "Host" %}}
-
-The JMX Metric Gatherer is intended to be run as an uber jar and configured with properties from the command line. 
-
-Please make sure that JRE is available on the host in which you are running the collector. If not, please make sure to download it, e.g.
-```
+```shell
 apt-get update && \
 apt-get -y install default-jre-headless
 ```
 
-Once you have done this, download the most recent release of the JMX Metric Gatherer JAR [here][1] and run:
+Download the [JMX Scraper JAR for OpenTelemetry Java Contrib v1.60.0][3]. Set each address variable in `host:port` format. Then run one or more of the following commands:
+
+```shell
+# Kafka broker
+java \
+  -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://${KAFKA_BROKER_JMX_ADDRESS}/jmxrmi \
+  -Dotel.jmx.target.system=kafka,jvm \
+  -Dotel.jmx.target.source=legacy \
+  -Dotel.metrics.exporter=otlp \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -jar /path/to/opentelemetry-jmx-scraper.jar
+
+# Kafka producer
+java \
+  -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://${KAFKA_PRODUCER_JMX_ADDRESS}/jmxrmi \
+  -Dotel.jmx.target.system=kafka-producer \
+  -Dotel.jmx.target.source=legacy \
+  -Dotel.metrics.exporter=otlp \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -jar /path/to/opentelemetry-jmx-scraper.jar
+
+# Kafka consumer
+java \
+  -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://${KAFKA_CONSUMER_JMX_ADDRESS}/jmxrmi \
+  -Dotel.jmx.target.system=kafka-consumer \
+  -Dotel.jmx.target.source=legacy \
+  -Dotel.metrics.exporter=otlp \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -jar /path/to/opentelemetry-jmx-scraper.jar
 ```
-// Kafka Broker
-java -jar -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://{KAFKA_BROKER_JMX_ADDRESS}/jmxrmi \ -Dotel.jmx.target.system=kafka,jvm \
--Dotel.metrics.exporter=otlp \
--Dotel.exporter.otlp.endpoint=http://localhost:4317 \
--jar /path/to/opentelemetry-jmx-metrics.jar
-
-// Kafka Producer
-java -jar -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://{KAFKA_PRODUCER_JMX_ADDRESS}/jmxrmi \ -Dotel.jmx.target.system=kafka-producer \
--Dotel.metrics.exporter=otlp \
--Dotel.exporter.otlp.endpoint=http://localhost:4317 \
--jar /path/to/opentelemetry-jmx-metrics.jar
-
-// Kafka Consumer
-java -jar -Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://{KAFKA_CONSUMER_JMX_ADDRESS}/jmxrmi \ -Dotel.jmx.target.system=kafka-consumer \
--Dotel.metrics.exporter=otlp \
--Dotel.exporter.otlp.endpoint=http://localhost:4317 \
--jar /path/to/opentelemetry-jmx-metrics.jar
-```
-
-[1]: https://github.com/open-telemetry/opentelemetry-java-contrib/releases
 
 {{% /tab %}}
 
 {{% tab "Kubernetes" %}}
 
-The JMX Metric Gatherer is intended to be run as an uber jar and configured with properties from the command line. 
+Use the following Dockerfile to build an image with a JRE and the JMX Scraper JAR:
 
-In order to deploy this in Kubernetes, you need to build an image which contains JRE and the JMX Metrics Gatherer Jar. Please see the Dockerfile below for an example image that contains JRE and JMX Metrics Gatherer Jar.
-
-Dockerfile:
 ```Dockerfile
 FROM alpine:latest as prep
 
-# JMX Metrics Gatherer Jar
-ARG JMX_GATHERER_JAR_VERSION=1.27.0
-ADD https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v${JMX_GATHERER_JAR_VERSION}/opentelemetry-jmx-metrics.jar /opt/opentelemetry-jmx-metrics.jar
-# nonroot user id (https://groups.google.com/g/distroless-users/c/-DpzCr7xRDY/m/eQqJmJroCgAJ)
+# JMX Scraper JAR
+ARG JMX_SCRAPER_JAR_VERSION=1.60.0
+ADD https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v${JMX_SCRAPER_JAR_VERSION}/opentelemetry-jmx-scraper.jar /opt/opentelemetry-jmx-scraper.jar
 ARG USER_UID=65532
-RUN chown ${USER_UID} /opt/opentelemetry-jmx-metrics.jar
+RUN chown ${USER_UID} /opt/opentelemetry-jmx-scraper.jar
 
 FROM gcr.io/distroless/java17-debian11:nonroot
 
-COPY --from=prep /opt/opentelemetry-jmx-metrics.jar /opt/opentelemetry-jmx-metrics.jar
+COPY --from=prep /opt/opentelemetry-jmx-scraper.jar /opt/opentelemetry-jmx-scraper.jar
 
 EXPOSE 4317 55680 55679
 ENTRYPOINT ["java"]
 CMD ["-Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://kafka:1099/jmxrmi", \
 "-Dotel.jmx.target.system=kafka,jvm", \
+"-Dotel.jmx.target.source=legacy", \
 "-Dotel.metrics.exporter=otlp", \
 "-Dotel.exporter.otlp.endpoint=http://otelcol:4317", \
 "-jar", \
-"/opt/opentelemetry-jmx-metrics.jar"]
+"/opt/opentelemetry-jmx-scraper.jar"]
 ```
+
+Replace `kafka:1099` with the broker's JMX address and `otelcol:4317` with the Collector's OTLP gRPC endpoint.
+
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -236,7 +169,7 @@ CMD ["-Dotel.jmx.service.url=service:jmx:rmi:///jndi/rmi://kafka:1099/jmxrmi", \
 
 See [Log Collection][4] for instructions on how to collect logs using the OpenTelemetry Collector.
 
-To appear in the out-of-the-box Kafka Dashboard, the Kafka logs need to be tagged with `source:kafka`. To do this, use an attributes processor:
+To include Kafka logs in the out-of-the-box Kafka Dashboard, use an attributes processor to add the `source:kafka` tag:
 
 ```yaml
 processors:
@@ -247,7 +180,7 @@ processors:
         action: insert
 ```
 
-In order to ensure this attribute only gets added to your Kafka logs, use [include/exclude filtering][8] of the attributes processor.
+To add this attribute only to Kafka logs, use [include/exclude filtering][8] in the attributes processor.
 
 ## Data collected
 
@@ -255,7 +188,7 @@ In order to ensure this attribute only gets added to your Kafka logs, use [inclu
 
 {{< mapping-table resource="kafkametrics.csv">}}
 
-### JMX receiver / JMX Metrics Gatherer
+### JMX Scraper
 
 #### Kafka broker
 
@@ -269,26 +202,17 @@ In order to ensure this attribute only gets added to your Kafka logs, use [inclu
 
 {{< mapping-table resource="kafka-consumer.csv">}}
 
-**Note:** In Datadog `-` gets translated to `_`. For example, `kafka.producer.request-rate` becomes `kafka.producer.request_rate`.
+**Note:** Datadog replaces hyphens (`-`) with underscores (`_`) in metric names. For example, `kafka.producer.request-rate` becomes `kafka.producer.request_rate`.
 
-For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][9].
+For the complete mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][9].
 
 ## Full example configuration
 
-For a full working example configuration with the Datadog exporter, see [`kafka.yaml`][5].
+For a complete configuration with the Datadog exporter, see [`kafka.yaml`][5].
 
 ## Example logging output
 
 ```
-Resource SchemaURL: https://opentelemetry.io/schemas/1.20.0
-Resource attributes:
-     -> service.name: Str(unknown_service:java)
-     -> telemetry.sdk.language: Str(java)
-     -> telemetry.sdk.name: Str(opentelemetry)
-     -> telemetry.sdk.version: Str(1.27.0)
-ScopeMetrics #0
-ScopeMetrics SchemaURL: 
-InstrumentationScope io.opentelemetry.contrib.jmxmetrics 1.27.0-alpha
 Metric #0
 Descriptor:
      -> Name: kafka.message.count
@@ -303,14 +227,13 @@ Timestamp: 2024-01-22 15:51:24.218 +0000 UTC
 Value: 25
 ```
 
-## Example app
+## Example application
 
-Please see the following [example application][6] which demonstrates the configurations discussed in this documentation. This example application is comprised of a producer, consumer, broker and zookeeper instance. It demonstrates using the Kafka metrics receiver, JMX Receiver and/or JMX Metrics Gatherer.
-
+See the [Kafka metrics example application][6] for a producer, consumer, broker, and ZooKeeper setup.
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kafkametricsreceiver
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver
-[3]: https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics 
+[2]: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/jmx-scraper
+[3]: https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.60.0
 [4]: /opentelemetry/collector_exporter/log_collection
 [5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/kafka.yaml
 [6]: https://github.com/DataDog/opentelemetry-examples/tree/main/apps/kafka-metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?

Fixes DOCS-15670

Replaces the removed OpenTelemetry Collector JMX receiver and deprecated JMX Metrics Gatherer instructions with JMX Scraper instructions. Adds broker-side RMI routing guidance and uses the legacy metric source to preserve existing metric names.

### Merge readiness

- [ ] Ready for merge

## For Datadog employees:

- ⚠️ Your branch name **MUST** follow the `<name>/<description>` convention and include the forward slash (`/`). If you've already created your PR with an incorrect branch name, please rename your branch and open a fresh PR.
- 🤖 **New**: Comment with `/review` to run an automated check that catches common issues before a Documentation team member reviews the PR.

### AI assistance

### Additional notes
